### PR TITLE
fix(button): Normalize Button's icon prop

### DIFF
--- a/components/Button/index.js
+++ b/components/Button/index.js
@@ -4,13 +4,14 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Button as SemanticButton } from 'semantic-ui-react'
 
-const Button = ({ className, ...otherProps }) => {
+import { normalizeIconProp } from '../utils/icons'
+
+const Button = ({ className, icon, ...otherProps }) => {
   const {
     children,
     content,
     disabled,
     ghost,
-    icon,
     primary,
     secondary,
     subtle
@@ -50,7 +51,13 @@ const Button = ({ className, ...otherProps }) => {
       'px-24': !iconOnly && !subtle
     }
   )
-  return <SemanticButton className={classes} {...otherProps} />
+  return (
+    <SemanticButton
+      className={classes}
+      icon={normalizeIconProp(icon)}
+      {...otherProps}
+    />
+  )
 }
 
 Button.propTypes = {


### PR DESCRIPTION
Semantic's icon prop frequently throws warnings for us because it expects icon names from a certain icon library, but we use another. The way out has been to pass the icon as a class name instead of just the icon's name, but that's annoying.

Since we're overriding these components now, it's our chance to automatically do this transformation from icon name to `{ className: iconName }`, hiding this from Orion's users.