### PR TITLE
chore(watch): Stop breaking watch due to errors on CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "enzyme-to-json": "^3.3.5",
     "gulp-add-src": "^1.0.0",
     "gulp-concat": "^2.6.1",
+    "gulp-plumber": "^1.2.1",
     "gulp-postcss": "^8.0.0",
     "husky": "^2.4.1",
     "jest": "^24.8.0",

--- a/tasks/build/tailwind.js
+++ b/tasks/build/tailwind.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
   minifyCSS = require('gulp-clean-css'),
+  plumber = require('gulp-plumber'),
   tasks = require('../config/tasks')
 
 module.exports = function() {
@@ -7,6 +8,7 @@ module.exports = function() {
 
   return gulp
     .src('orion.css')
+    .pipe(plumber())
     .pipe(
       postcss([
         require('postcss-import'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6067,7 +6067,7 @@ gulp-notify@^3.2.0:
     plugin-error "^0.1.2"
     through2 "^2.0.3"
 
-gulp-plumber@^1.2.0:
+gulp-plumber@^1.2.0, gulp-plumber@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/gulp-plumber/-/gulp-plumber-1.2.1.tgz#d38700755a300b9d372318e4ffb5ff7ced0b2c84"
   integrity sha512-mctAi9msEAG7XzW5ytDVZ9PxWMzzi1pS2rBH7lA095DhMa6KEXjm+St0GOCc567pJKJ/oCvosVAZEpAey0q2eQ==


### PR DESCRIPTION
This gulp-plumber npm package swallows the errors and just outputs them on the screen. The developer won't have to run the watch process again, just fix the error as usual.

<img width="720" alt="Screen Shot 2019-06-12 at 10 51 08 AM" src="https://user-images.githubusercontent.com/5216049/59356941-4e9ded80-8d00-11e9-9ed8-92eef9c0738a.png">
