### PR TITLE
fix(layout): Fix buttons inside Layout

### DIFF
--- a/components/Button/button.css
+++ b/components/Button/button.css
@@ -8,5 +8,5 @@
 }
 
 .orion-button.transition-default {
-  transition-property: background-color opacity;
+  transition-property: background-color, opacity;
 }

--- a/components/Button/index.js
+++ b/components/Button/index.js
@@ -22,12 +22,14 @@ const Button = ({ className, icon, ...otherProps }) => {
   const regularPrimary = primary && !subtle
   const subtlePrimary = primary && subtle
 
-  const regularSecondary = secondary && !subtle
-  const subtleSecondary = secondary && subtle
+  const isSecondary = secondary || (!primary && !ghost)
+
+  const regularSecondary = isSecondary && !subtle
+  const subtleSecondary = isSecondary && subtle
 
   const classes = cx(
     className,
-    'orion-button h-40 rounded-full font-default outline-none flex items-center transition-default',
+    'orion-button h-40 rounded-full font-default outline-none inline-flex items-center transition-default',
     {
       'bg-wave-500 text-white': regularPrimary,
       'bg-gray-900-8 text-gray-900': regularSecondary,

--- a/components/Wizard/Footer/BasicControls.js
+++ b/components/Wizard/Footer/BasicControls.js
@@ -1,7 +1,8 @@
+import _ from 'lodash'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Button } from 'semantic-ui-react'
+import Button from '../../Button'
 
 const Buttons = {
   CANCEL: 'cancel',
@@ -56,50 +57,44 @@ class WizardFooterBasicControls extends Component {
     const isLastStep = currentStep === totalSteps - 1
     return (
       <React.Fragment>
-        {Button.create(buttons[Buttons.CANCEL], {
-          autoGenerateKey: false,
-          defaultProps: {
-            onClick: onCancel,
-            type: 'button'
-          }
+        {this.getButton(buttons[Buttons.CANCEL], {
+          onClick: onCancel,
+          type: 'button'
         })}
         {showSaveButton &&
           !isLastStep &&
-          Button.create(buttons[Buttons.SAVE], {
-            autoGenerateKey: false,
-            defaultProps: {
-              onClick: onSave,
-              type: 'submit'
-            }
+          this.getButton(buttons[Buttons.SAVE], {
+            onClick: onSave,
+            type: 'submit'
           })}
         {(currentStep > 0 || showBackOnFirstStep) &&
-          Button.create(buttons[Buttons.PREVIOUS], {
-            autoGenerateKey: false,
-            defaultProps: {
-              onClick: this.handlePrevious,
-              type: 'button'
-            }
+          this.getButton(buttons[Buttons.PREVIOUS], {
+            onClick: this.handlePrevious,
+            type: 'button'
           })}
         {!isLastStep &&
-          Button.create(buttons[Buttons.NEXT], {
-            autoGenerateKey: false,
-            defaultProps: {
-              className: 'blue',
-              onClick: this.handleNext,
-              type: 'submit'
-            }
+          this.getButton(buttons[Buttons.NEXT], {
+            primary: true,
+            onClick: this.handleNext,
+            type: 'submit'
           })}
         {isLastStep &&
-          Button.create(buttons[Buttons.FINISH], {
-            autoGenerateKey: false,
-            defaultProps: {
-              className: 'blue',
-              onClick: onFinish,
-              type: 'submit'
-            }
+          this.getButton(buttons[Buttons.FINISH], {
+            primary: true,
+            onClick: onFinish,
+            type: 'submit'
           })}
       </React.Fragment>
     )
+  }
+
+  getButton = (options, defaultProps) => {
+    if (React.isValidElement(options)) {
+      return options
+    }
+
+    const customProps = _.isString(options) ? { content: options } : options
+    return <Button {...defaultProps} {...customProps} />
   }
 
   handleNext = () => {

--- a/components/Wizard/Footer/__tests__/WizardFooterBasicControls.test.js
+++ b/components/Wizard/Footer/__tests__/WizardFooterBasicControls.test.js
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import { Button } from 'semantic-ui-react'
+import Button from '../../../Button'
 
 import WizardFooterBasicControls from '../BasicControls'
 

--- a/components/Wizard/Footer/__tests__/__snapshots__/WizardFooterBasicControls.test.js.snap
+++ b/components/Wizard/Footer/__tests__/__snapshots__/WizardFooterBasicControls.test.js.snap
@@ -3,24 +3,18 @@
 exports[`WizardFooterBasicControls should render "cancel", "previous" and "next" buttons 1`] = `
 <Fragment>
   <Button
-    as="button"
     content="Cancel"
-    role="button"
     type="button"
   />
   <Button
-    as="button"
     content="Previous"
     onClick={[Function]}
-    role="button"
     type="button"
   />
   <Button
-    as="button"
-    className="blue"
     content="Next"
     onClick={[Function]}
-    role="button"
+    primary={true}
     type="submit"
   />
 </Fragment>
@@ -29,25 +23,17 @@ exports[`WizardFooterBasicControls should render "cancel", "previous" and "next"
 exports[`WizardFooterBasicControls should render custom buttons when given 1`] = `
 <Fragment>
   <Button
-    as="button"
     content="Custom Cancel"
-    role="button"
     type="button"
   />
   <Button
-    as="button"
     className="customPreviousClass"
     content="Custom Previous"
     onClick={[Function]}
-    role="button"
     type="button"
   />
   <Button
-    as="button"
-    className="blue customNextClass"
-    onClick={[Function]}
-    role="button"
-    type="submit"
+    className="customNextClass"
   >
     Custom Next
   </Button>
@@ -57,24 +43,18 @@ exports[`WizardFooterBasicControls should render custom buttons when given 1`] =
 exports[`WizardFooterBasicControls when the "showBackOnFirstStep" prop is true when the current step is the first step should render "cancel", "previous" and "next" buttons 1`] = `
 <Fragment>
   <Button
-    as="button"
     content="Cancel"
-    role="button"
     type="button"
   />
   <Button
-    as="button"
     content="Previous"
     onClick={[Function]}
-    role="button"
     type="button"
   />
   <Button
-    as="button"
-    className="blue"
     content="Next"
     onClick={[Function]}
-    role="button"
+    primary={true}
     type="submit"
   />
 </Fragment>
@@ -83,30 +63,22 @@ exports[`WizardFooterBasicControls when the "showBackOnFirstStep" prop is true w
 exports[`WizardFooterBasicControls when the "showSaveButton" prop is set to "true" should render "cancel", "previous", "save" and "next" buttons 1`] = `
 <Fragment>
   <Button
-    as="button"
     content="Cancel"
-    role="button"
     type="button"
   />
   <Button
-    as="button"
     content="Save"
-    role="button"
     type="submit"
   />
   <Button
-    as="button"
     content="Previous"
     onClick={[Function]}
-    role="button"
     type="button"
   />
   <Button
-    as="button"
-    className="blue"
     content="Next"
     onClick={[Function]}
-    role="button"
+    primary={true}
     type="submit"
   />
 </Fragment>
@@ -115,17 +87,13 @@ exports[`WizardFooterBasicControls when the "showSaveButton" prop is set to "tru
 exports[`WizardFooterBasicControls when the current step is the first step should render "cancel" and "next" buttons 1`] = `
 <Fragment>
   <Button
-    as="button"
     content="Cancel"
-    role="button"
     type="button"
   />
   <Button
-    as="button"
-    className="blue"
     content="Next"
     onClick={[Function]}
-    role="button"
+    primary={true}
     type="submit"
   />
 </Fragment>
@@ -134,23 +102,17 @@ exports[`WizardFooterBasicControls when the current step is the first step shoul
 exports[`WizardFooterBasicControls when the current step is the last step should render "cancel", "previous" and "finish" buttons 1`] = `
 <Fragment>
   <Button
-    as="button"
     content="Cancel"
-    role="button"
     type="button"
   />
   <Button
-    as="button"
     content="Previous"
     onClick={[Function]}
-    role="button"
     type="button"
   />
   <Button
-    as="button"
-    className="blue"
     content="Finish"
-    role="button"
+    primary={true}
     type="submit"
   />
 </Fragment>

--- a/stories/Layout/index.stories.js
+++ b/stories/Layout/index.stories.js
@@ -63,7 +63,7 @@ const StoryLayout = ({ noBreadcrumb, withWarning, ...otherProps }) => (
         <Layout.HeaderTitle>Home Title</Layout.HeaderTitle>
         <Layout.HeaderControls>
           <Button>Cancel</Button>
-          <Button className={otherProps.color}>Save</Button>
+          <Button primary>Save</Button>
         </Layout.HeaderControls>
       </Layout.Header>
       <Layout.MainContent>
@@ -117,9 +117,7 @@ const StoryLayout = ({ noBreadcrumb, withWarning, ...otherProps }) => (
 )
 
 storiesOf('Layout', module)
-  .add('blue', () => <StoryLayout color="blue" />)
-  .add('pink', () => <StoryLayout color="pink" />)
-  .add('green', () => <StoryLayout color="green" />)
-  .add('no breadcrumb', () => <StoryLayout color="blue" noBreadcrumb />)
-  .add('no sidebar', () => <StoryLayout color="blue" noSidebar />)
-  .add('with warning', () => <StoryLayout color="blue" withWarning />)
+  .add('basic', () => <StoryLayout />)
+  .add('no breadcrumb', () => <StoryLayout noBreadcrumb />)
+  .add('no sidebar', () => <StoryLayout noSidebar />)
+  .add('with warning', () => <StoryLayout withWarning />)


### PR DESCRIPTION
I noticed that buttons inside Layout were still the old ones.
Layout is still going to change, so I wasn't going to fix these, but I realized it surfaced some small bugs in the new button, so I ended up fixing everything:

- Changed Layout to start using the new button
- Fixed button props to the new format
- Stopped using `Button.create` from semantic (our Button doesn't have it) and switched it with just simple logic instead.
- Made small fixes to Button: made it be secondary by default, as well as inline (instead of block).

**Before**
<img width="1105" alt="Screen Shot 2019-06-12 at 1 09 08 PM" src="https://user-images.githubusercontent.com/5216049/59367842-52873b00-8d13-11e9-8405-add5fb44f3c8.png">
<img width="1155" alt="Screen Shot 2019-06-12 at 1 09 19 PM" src="https://user-images.githubusercontent.com/5216049/59367843-52873b00-8d13-11e9-8089-d38e8bd96a5d.png">

**After**
<img width="1173" alt="Screen Shot 2019-06-12 at 12 58 02 PM" src="https://user-images.githubusercontent.com/5216049/59367779-31bee580-8d13-11e9-83cc-6b4954057b88.png">
<img width="1216" alt="Screen Shot 2019-06-12 at 12 58 11 PM" src="https://user-images.githubusercontent.com/5216049/59367780-31bee580-8d13-11e9-96d1-389b1186092e.png">
