### PR TITLE
 feature(icons): Style Icon

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<link
+  href="https://fonts.googleapis.com/icon?family=Material+Icons"
+  rel="stylesheet"
+/>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,38 @@
 # Orion
 
 In Loco's component library, based on React Semantic UI.
+
 You can see and interact with the components [here](https://inloco.github.io/orion).
 
-## Installing
+## Usage
+
+1. Install via NPM or Yarn:
 
 ```sh
   npm install --save @inloco/orion
   #or
   yarn add @inloco/orion
+```
+
+2. Add Material Icons Font to your HTML:
+
+```html
+<link
+  href="https://fonts.googleapis.com/icon?family=Material+Icons"
+  rel="stylesheet"
+/>
+```
+
+3. Import Orion's CSS on your react app:
+
+```js
+import '@inloco/orion/dist/orion.css'
+```
+
+4. Import and use Orion's components as needed:
+
+```js
+import { Button, Dropdown } from '@inloco/orion'
 ```
 
 ## Contributing

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -4,14 +4,15 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Button as SemanticButton } from 'semantic-ui-react'
 
-import { normalizeIconProp } from '../utils/icons'
+import { createShorthandFactory } from '../utils/factories'
 
-const Button = ({ className, icon, ...otherProps }) => {
+const Button = ({ className, ...otherProps }) => {
   const {
     children,
     content,
     disabled,
     ghost,
+    icon,
     primary,
     secondary,
     subtle
@@ -53,18 +54,17 @@ const Button = ({ className, icon, ...otherProps }) => {
       'px-24': !iconOnly && !subtle
     }
   )
-  return (
-    <SemanticButton
-      className={classes}
-      icon={normalizeIconProp(icon)}
-      {...otherProps}
-    />
-  )
+  return <SemanticButton className={classes} {...otherProps} />
 }
 
 Button.propTypes = {
   ghost: PropTypes.bool,
   subtle: PropTypes.bool
 }
+
+// Overriding original factory. See src/utils/factories.js for more details.
+SemanticButton.create = createShorthandFactory(Button, value => ({
+  content: value
+}))
 
 export default Button

--- a/src/Checkbox/checkbox.css
+++ b/src/Checkbox/checkbox.css
@@ -42,7 +42,7 @@
 .orion-checkbox input[type='checkbox']:indeterminate ~ label:after {
   @apply absolute top-0 left-0 h-16 w-16;
   @apply flex items-center justify-center text-white;
-  font-family: 'Icons';
+  font-family: 'Material Icons';
 }
 
 .orion-checkbox input[type='checkbox']:checked ~ label:after {

--- a/src/Icon/Icon.stories.js
+++ b/src/Icon/Icon.stories.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { text, withKnobs } from '@storybook/addon-knobs'
+
+import Icon from './'
+
+storiesOf('Icon', module)
+  .addDecorator(withKnobs)
+  .add('basic', () => <Icon name={text('icon', 'cloud')} />)

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -1,0 +1,26 @@
+import _ from 'lodash'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Icon as SemanticIcon } from 'semantic-ui-react'
+
+import { createShorthandFactory } from '../utils/factories'
+
+const Icon = ({ className, name, ...otherProps }) => {
+  const classes = cx(className, 'icon material-icons text-lg')
+  return (
+    <i className={classes} {...otherProps}>
+      {name}
+    </i>
+  )
+}
+
+Icon.propTypes = {
+  className: PropTypes.string,
+  name: PropTypes.string
+}
+
+// Overriding original factory. See src/utils/factories.js for more details.
+SemanticIcon.create = createShorthandFactory(Icon, value => ({ name: value }))
+
+export default Icon

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Input as SemanticInput } from 'semantic-ui-react'
 
+import { createShorthandFactory } from '../utils/factories'
+
 const Sizes = {
   DEFAULT: 'default',
   SMALL: 'small'
@@ -21,5 +23,8 @@ Input.propTypes = {
   size: PropTypes.oneOf([Sizes.DEFAULT, Sizes.SMALL]),
   warning: PropTypes.bool
 }
+
+// Overriding original factory. See src/utils/factories.js for more details.
+SemanticInput.create = createShorthandFactory(Input, type => ({ type }))
 
 export default Input

--- a/src/Label/index.js
+++ b/src/Label/index.js
@@ -2,9 +2,10 @@ import _ from 'lodash'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Icon, Label as SemanticLabel } from 'semantic-ui-react'
+import { Label as SemanticLabel } from 'semantic-ui-react'
 
-import { normalizeIconProp } from '../utils/icons'
+import Icon from '../Icon'
+import { createShorthandFactory } from '../utils/factories'
 
 const Sizes = {
   DEFAULT: 'default',
@@ -14,12 +15,11 @@ const Sizes = {
 const Label = ({
   children,
   className,
-  icon,
+  content,
   onRemove,
   size,
   ...otherProps
 }) => {
-  const { content } = otherProps
   const classes = cx(
     className,
     'orion-label inline-flex items-center px-8 bg-gray-900-8 rounded leading-20',
@@ -40,7 +40,7 @@ const Label = ({
     children = (
       <React.Fragment>
         <div className={removeIconClasses} onClick={onRemove}>
-          <Icon className="clear" size="big" />
+          <Icon name="clear" size="big" />
         </div>
         {children || content}
       </React.Fragment>
@@ -49,7 +49,7 @@ const Label = ({
   return (
     <SemanticLabel
       className={classes}
-      icon={normalizeIconProp(icon)}
+      content={children ? null : content}
       {...otherProps}>
       {children}
     </SemanticLabel>
@@ -63,5 +63,10 @@ Label.propTypes = {
 Label.defaultProps = {
   size: Sizes.DEFAULT
 }
+
+// Overriding original factory. See src/utils/factories.js for more details.
+SemanticLabel.create = createShorthandFactory(Label, value => ({
+  content: value
+}))
 
 export default Label

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export * from './Form'
 export * from './Layout'
 export * from './Wizard'
 
+export { default as Icon } from './Icon'
 export { default as Button } from './Button'
 export { default as Checkbox } from './Checkbox'
 export { default as Input } from './Input'

--- a/src/utils/factories.js
+++ b/src/utils/factories.js
@@ -1,0 +1,4 @@
+// Semantic UI components frequently reference each other internally via shorthand
+// factories. Overriding these factories enable us to keep the flexibility of
+// shorthand props while also customizing the behavior and styles of components.
+export { createShorthandFactory } from 'semantic-ui-react/dist/es/lib'

--- a/src/utils/factories.js
+++ b/src/utils/factories.js
@@ -1,4 +1,157 @@
-// Semantic UI components frequently reference each other internally via shorthand
-// factories. Overriding these factories enable us to keep the flexibility of
-// shorthand props while also customizing the behavior and styles of components.
-export { createShorthandFactory } from 'semantic-ui-react/dist/es/lib'
+import _ from 'lodash'
+import cx from 'classnames'
+import React, { cloneElement, isValidElement } from 'react'
+
+// COPIED FROM semantic-ui-react, as they don't export it:
+// https://github.com/Semantic-Org/Semantic-UI-React/blob/master/src/lib/factories.js
+
+// ============================================================
+// Factories
+// ============================================================
+
+/**
+ * A more robust React.createElement. It can create elements from primitive values.
+ *
+ * @param {function|string} Component A ReactClass or string
+ * @param {function} mapValueToProps A function that maps a primitive value to the Component props
+ * @param {string|object|function} val The value to create a ReactElement from
+ * @param {Object} [options={}]
+ * @param {object} [options.defaultProps={}] Default props object
+ * @param {object|function} [options.overrideProps={}] Override props object or function (called with regular props)
+ * @param {boolean} [options.autoGenerateKey=true] Whether or not automatic key generation is allowed
+ * @returns {object|null}
+ */
+export function createShorthand(Component, mapValueToProps, val, options = {}) {
+  if (typeof Component !== 'function' && typeof Component !== 'string') {
+    throw new Error('createShorthand() Component must be a string or function.')
+  }
+  // short circuit noop values
+  if (_.isNil(val) || _.isBoolean(val)) return null
+
+  const valIsString = _.isString(val)
+  const valIsNumber = _.isNumber(val)
+  const valIsFunction = _.isFunction(val)
+  const valIsReactElement = isValidElement(val)
+  const valIsPropsObject = _.isPlainObject(val)
+  const valIsPrimitiveValue = valIsString || valIsNumber || _.isArray(val)
+
+  // unhandled type return null
+  /* eslint-disable no-console */
+  if (
+    !valIsFunction &&
+    !valIsReactElement &&
+    !valIsPropsObject &&
+    !valIsPrimitiveValue
+  ) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(
+        [
+          'Shorthand value must be a string|number|array|object|ReactElement|function.',
+          ' Use null|undefined|boolean for none',
+          ` Received ${typeof val}.`
+        ].join('')
+      )
+    }
+    return null
+  }
+  /* eslint-enable no-console */
+
+  // ----------------------------------------
+  // Build up props
+  // ----------------------------------------
+  const { defaultProps = {} } = options
+
+  // User's props
+  const usersProps =
+    (valIsReactElement && val.props) ||
+    (valIsPropsObject && val) ||
+    (valIsPrimitiveValue && mapValueToProps(val))
+
+  // Override props
+  let { overrideProps = {} } = options
+  overrideProps = _.isFunction(overrideProps)
+    ? overrideProps({ ...defaultProps, ...usersProps })
+    : overrideProps
+
+  // Merge props
+  /* eslint-disable react/prop-types */
+  const props = { ...defaultProps, ...usersProps, ...overrideProps }
+
+  // Merge className
+  if (
+    defaultProps.className ||
+    overrideProps.className ||
+    usersProps.className
+  ) {
+    const mergedClassesNames = cx(
+      defaultProps.className,
+      overrideProps.className,
+      usersProps.className
+    )
+    props.className = _.uniq(mergedClassesNames.split(' ')).join(' ')
+  }
+
+  // Merge style
+  if (defaultProps.style || overrideProps.style || usersProps.style) {
+    props.style = {
+      ...defaultProps.style,
+      ...usersProps.style,
+      ...overrideProps.style
+    }
+  }
+
+  // ----------------------------------------
+  // Get key
+  // ----------------------------------------
+
+  // Use key, childKey, or generate key
+  if (_.isNil(props.key)) {
+    const { childKey } = props
+    const { autoGenerateKey = true } = options
+
+    if (!_.isNil(childKey)) {
+      // apply and consume the childKey
+      props.key = typeof childKey === 'function' ? childKey(props) : childKey
+      delete props.childKey
+    } else if (autoGenerateKey && (valIsString || valIsNumber)) {
+      // use string/number shorthand values as the key
+      props.key = val
+    }
+  }
+
+  // ----------------------------------------
+  // Create Element
+  // ----------------------------------------
+
+  // Clone ReactElements
+  if (valIsReactElement) return cloneElement(val, props)
+
+  // Create ReactElements from built up props
+  if (valIsPrimitiveValue || valIsPropsObject) return <Component {...props} />
+
+  // Call functions with args similar to createElement()
+  if (valIsFunction) return val(Component, props, props.children)
+  /* eslint-enable react/prop-types */
+}
+
+// ============================================================
+// Factory Creators
+// ============================================================
+
+/**
+ * Creates a `createShorthand` function that is waiting for a value and options.
+ *
+ * @param {function|string} Component A ReactClass or string
+ * @param {function} mapValueToProps A function that maps a primitive value to the Component props
+ * @returns {function} A shorthand factory function waiting for `val` and `defaultProps`.
+ */
+export function createShorthandFactory(Component, mapValueToProps) {
+  if (typeof Component !== 'function' && typeof Component !== 'string') {
+    throw new Error(
+      'createShorthandFactory() Component must be a string or function.'
+    )
+  }
+
+  return (val, options) =>
+    createShorthand(Component, mapValueToProps, val, options)
+}


### PR DESCRIPTION
Nada mudou visualmente, só estou consertando o componente `Icon` agora que tiramos o CSS do semantic UI do projeto.

Vamos passar a usar o Material Icons direto da CDN da Google:
- É a forma recomendada pelo Material.
- É melhor pra performance, todo mundo bate nessa CDN.
- Teremos sempre os ícones mais atualizados (isso fazia falta, perdíamos de usar alguns mais novos).
- Única desvantagem: os projetos têm que adicionar o `<link>` pra essa CDN manualmente, não virá já com o css do Orion. Mas vale a pena essa config extra e adicionei isso no README.md.