### PR TITLE
 feature(inputAndDropdown): Style fluid input and dropdown

### DIFF
--- a/src/Dropdown/Dropdown.stories.js
+++ b/src/Dropdown/Dropdown.stories.js
@@ -27,6 +27,7 @@ storiesOf('Dropdown', module)
         placeholder={text('Placeholder', 'Select Developer', 'Content')}
         selection
         options={object('Options', developerOptions, 'Content')}
+        fluid={boolean('Fluid', false, 'Content')}
         search={boolean('Search', false, 'Type')}
         multiple={boolean('Multiple', false, 'Type')}
         size={sizeKnob()}

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -14,13 +14,14 @@ const DROPDOWN_ICON = {
 }
 
 const Dropdown = ({ className, size, ...otherProps }) => {
-  const { disabled } = otherProps
+  const { disabled, fluid } = otherProps
   const classes = cx(
     className,
     'orion-dropdown',
     'inline-flex items-center justify-between relative outline-none',
     'border border-gray-900-24 px-16 rounded',
     {
+      'w-full': fluid,
       'h-48': size === Sizes.DEFAULT,
       'h-32': size === Sizes.SMALL,
       'bg-white cursor-pointer hover:shadow-field-hover focus:shadow-field-focus': !disabled,

--- a/src/Input/Input.stories.js
+++ b/src/Input/Input.stories.js
@@ -20,6 +20,7 @@ storiesOf('Input', module)
         error={error}
         size={sizeKnob()}
         disabled={disabled}
+        fluid={boolean('fluid', false)}
       />
     )
   })

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -12,8 +12,10 @@ const Sizes = {
 }
 
 const Input = ({ className, warning, size, ...otherProps }) => {
+  const { fluid } = otherProps
   const classes = cx(className, size, 'orion-input inline-flex', {
-    warning
+    warning,
+    'w-full': fluid
   })
 
   return <SemanticInput className={classes} {...otherProps} />

--- a/src/Input/input.css
+++ b/src/Input/input.css
@@ -34,3 +34,7 @@
 .orion-input.warning > input {
   @apply border-yellow-500;
 }
+
+.orion-input.fluid > input {
+  @apply w-full;
+}


### PR DESCRIPTION
Esquecemos dessa flag `fluid`, ela é bastante útil nesses fields. Adicionei a input e dropdown.

**Regular input/dropdown**
<img width="667" alt="Screen Shot 2019-06-13 at 4 07 55 PM" src="https://user-images.githubusercontent.com/5216049/59460518-a9fdd780-8df5-11e9-9423-25e9b5735363.png">
<img width="671" alt="Screen Shot 2019-06-13 at 4 07 46 PM" src="https://user-images.githubusercontent.com/5216049/59460517-a9654100-8df5-11e9-8c7d-f043f332ac13.png">

**Fluid input/dropdown**
<img width="667" alt="Screen Shot 2019-06-13 at 4 08 01 PM" src="https://user-images.githubusercontent.com/5216049/59460528-b124e580-8df5-11e9-8763-a5d8b10b65ff.png">
<img width="666" alt="Screen Shot 2019-06-13 at 4 07 51 PM" src="https://user-images.githubusercontent.com/5216049/59460527-b124e580-8df5-11e9-91da-fc86d0d92ae6.png">
