### PR TITLE
feature(dropdown): Style multiple dropdown with search

### DIFF
--- a/src/Dropdown/dropdown.css
+++ b/src/Dropdown/dropdown.css
@@ -1,6 +1,6 @@
 .ui.dropdown {
-  @apply inline-flex items-center justify-between relative;
-  @apply cursor-pointer h-48 px-16 outline-none select-none;
+  @apply flex-wrap inline-flex items-center relative;
+  @apply cursor-pointer min-h-48 px-16 outline-none select-none;
   min-width: 256px;
 }
 
@@ -13,11 +13,7 @@
 }
 
 .ui.dropdown.small {
-  @apply h-32;
-}
-
-.ui.dropdown.search input {
-  @apply absolute bg-transparent outline-none;
+  @apply min-h-32;
 }
 
 .ui.dropdown .text {
@@ -51,20 +47,72 @@
   @apply bg-gray-900-4;
 }
 
+.ui.dropdown.disabled {
+  @apply pointer-events-none cursor-default;
+}
+
 .ui.dropdown.selection.active .orion-dropdown__icon {
   transform: rotate(-180deg);
 }
 
-.ui.dropdown.multiple .orion-label {
+.orion-dropdown__icon {
+  @apply ml-auto -mr-8 transition-default;
+}
+
+/**
+ * Search
+ */
+
+.ui.dropdown.search {
+  @apply inline-flex cursor-text;
+}
+
+.ui.dropdown.search input {
+  @apply absolute bg-transparent outline-none;
+}
+
+.ui.dropdown.search.active input:focus + .text {
+  @apply text-gray-800;
+}
+
+/**
+ * Multiple
+ */
+
+.ui.dropdown.multiple .ui.label {
   @apply mr-8;
 }
 
-.orion-dropdown__icon {
-  @apply -mr-8 transition-default;
+.ui.dropdown.multiple.small > .ui.label {
+  @apply h-24 !important;
 }
 
-.ui.dropdown.disabled {
-  @apply pointer-events-none cursor-default;
+/**
+ * Search + Multiple
+ */
+
+.ui.dropdown.search.multiple {
+  @apply h-auto py-4;
+}
+
+.ui.dropdown.search.multiple > .ui.label {
+  @apply my-2;
+}
+
+.ui.dropdown.search.multiple > input {
+  @apply h-32 my-2 static w-32 max-w-full;
+}
+
+.ui.dropdown.search.multiple.small > input {
+  @apply h-24;
+}
+
+.ui.dropdown.search.multiple > .sizer {
+  @apply hidden p-2;
+}
+
+.ui.dropdown.search.multiple > .text {
+  @apply absolute;
 }
 
 /**
@@ -85,12 +133,4 @@
 
 .ui.dropdown.selection:focus {
   @apply shadow-field-focus;
-}
-
-/**
- * Search
- */
-
-.ui.dropdown.search {
-  @apply inline-flex cursor-text;
 }


### PR DESCRIPTION
I've styled the multiple dropdown and the search dropdown separately. But I've noticed that when they're both enabled, we need some extra CSS rules.

![2019-06-14 13 34 11](https://user-images.githubusercontent.com/5216049/59524029-35847080-8ea9-11e9-863f-dc3666f506e7.gif)
