### PR TITLE
refactor(input): move classes from component to css. Remove orion-input

### DIFF
--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -13,7 +13,7 @@ const Sizes = {
 
 const Input = ({ className, warning, size, ...otherProps }) => {
   const { fluid } = otherProps
-  const classes = cx(className, size, 'orion-input inline-flex relative', {
+  const classes = cx(className, size, {
     warning,
     'w-full': fluid
   })

--- a/src/Input/input.css
+++ b/src/Input/input.css
@@ -1,41 +1,44 @@
-.orion-input > input {
-  @apply h-48 px-16 flex justify-center outline-none;
+.input {
+  @apply inline-flex relative;
+}
+.input > input {
+  @apply h-48 pl-16 flex justify-center outline-none;
 }
 
-.orion-input:not(.labeled) > input {
+.input:not(.labeled) > input {
   @apply bg-white border border-gray-900-24 rounded;
 }
 
-.orion-input > input::placeholder {
-  @apply text-gray-800;
+.input > input::placeholder {
+  @apply text-gray-800 text-base opacity-100;
 }
 
-.orion-input > input:disabled {
+.input > input:disabled {
   @apply bg-gray-900-8;
 }
 
-.orion-input > input:hover {
+.input > input:hover {
   @apply shadow-field-hover;
 }
 
-.orion-input > input:active,
-.orion-input > input:focus {
+.input > input:active,
+.input > input:focus {
   @apply shadow-field-focus;
 }
 
-.orion-input.small > input {
+.input.small > input {
   @apply h-32;
 }
 
-.orion-input.error > input {
+.input.error > input {
   @apply border-magenta-500;
 }
 
-.orion-input.warning > input {
+.input.warning > input {
   @apply border-yellow-500;
 }
 
-.orion-input.fluid > input {
+.input.fluid > input {
   @apply w-full;
 }
 
@@ -43,10 +46,10 @@
  * Icon
  */
 
-.orion-input.icon > input {
+.input.icon > input {
   @apply pr-40;
 }
 
-.orion-input.icon > input ~ .icon {
+.input.icon > input ~ .icon {
   @apply absolute right-0 w-40 h-full flex items-center justify-center;
 }

--- a/src/Input/input.css
+++ b/src/Input/input.css
@@ -1,44 +1,44 @@
-.input {
+.ui.input {
   @apply inline-flex relative;
 }
-.input > input {
+.ui.input > input {
   @apply h-48 pl-16 flex justify-center outline-none;
 }
 
-.input:not(.labeled) > input {
+.ui.input:not(.labeled) > input {
   @apply bg-white border border-gray-900-24 rounded;
 }
 
-.input > input::placeholder {
+.ui.input > input::placeholder {
   @apply text-gray-800 text-base opacity-100;
 }
 
-.input > input:disabled {
+.ui.input > input:disabled {
   @apply bg-gray-900-8;
 }
 
-.input > input:hover {
+.ui.input > input:not(:disabled):hover {
   @apply shadow-field-hover;
 }
 
-.input > input:active,
-.input > input:focus {
+.ui.input > input:not(:disabled):active,
+.ui.input > input:not(:disabled):focus {
   @apply shadow-field-focus;
 }
 
-.input.small > input {
+.ui.input.small > input {
   @apply h-32;
 }
 
-.input.error > input {
+.ui.input.error > input {
   @apply border-magenta-500;
 }
 
-.input.warning > input {
+.ui.input.warning > input {
   @apply border-yellow-500;
 }
 
-.input.fluid > input {
+.ui.input.fluid > input {
   @apply w-full;
 }
 
@@ -46,10 +46,10 @@
  * Icon
  */
 
-.input.icon > input {
+.ui.input.icon > input {
   @apply pr-40;
 }
 
-.input.icon > input ~ .icon {
+.ui.input.icon > input ~ .icon {
   @apply absolute right-0 w-40 h-full flex items-center justify-center;
 }

--- a/src/Input/input.css
+++ b/src/Input/input.css
@@ -14,15 +14,15 @@
 }
 
 .ui.input > input:disabled {
-  @apply bg-gray-900-8;
+  @apply bg-gray-900-8 pointer-events-none;
 }
 
-.ui.input > input:not(:disabled):hover {
+.ui.input > input:hover {
   @apply shadow-field-hover;
 }
 
-.ui.input > input:not(:disabled):active,
-.ui.input > input:not(:disabled):focus {
+.ui.input > input:active,
+.ui.input > input:focus {
   @apply shadow-field-focus;
 }
 


### PR DESCRIPTION
Já que adicionar a classe diretamente no componente adiciona `!important` e a gente não quer este comportamento no Orion, estou movendo as classes do componente para o CSS no input, além de remover o `orion-input`.