### PR TITLE
feature(dismissible-message): Add dismissible icon

### DIFF
--- a/src/Message/Message.stories.js
+++ b/src/Message/Message.stories.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { boolean, text, withKnobs } from '@storybook/addon-knobs'
+import { action } from '@storybook/addon-actions'
+
 import Message from './'
 
 storiesOf('Message', module)
@@ -20,5 +22,15 @@ storiesOf('Message', module)
       error={boolean('Error', false)}
       success={boolean('Success', false)}
       warning={boolean('Warning', false)}
+    />
+  ))
+  .add('Dismissible', () => (
+    <Message
+      content={text('Content', 'Your account was created')}
+      header={text('Header', 'Success')}
+      error={boolean('Error', false)}
+      success={boolean('Success', false)}
+      warning={boolean('Warning', false)}
+      onDismiss={action('onDimiss')}
     />
   ))

--- a/src/Message/index.js
+++ b/src/Message/index.js
@@ -5,7 +5,14 @@ import { Message as SemanticMessage } from 'semantic-ui-react'
 
 import Icon from '../Icon'
 
-const Message = ({ error, success, warning, className, ...otherProps }) => {
+const Message = ({
+  error,
+  success,
+  warning,
+  className,
+  onDismiss,
+  ...otherProps
+}) => {
   const { header } = otherProps
 
   const classes = cx(className, {
@@ -23,7 +30,20 @@ const Message = ({ error, success, warning, className, ...otherProps }) => {
     <Icon name="check" className="text-green-500" />
   )
 
-  return <SemanticMessage icon={icon} className={classes} {...otherProps} />
+  const dismissIcon = onDismiss && (
+    <Icon
+      name="close"
+      className="orion-message__close-icon"
+      onClick={onDismiss}
+    />
+  )
+
+  return (
+    <div className="orion-message">
+      {dismissIcon}
+      <SemanticMessage icon={icon} className={classes} {...otherProps} />
+    </div>
+  )
 }
 
 Message.propTypes = {

--- a/src/Message/message.css
+++ b/src/Message/message.css
@@ -18,6 +18,16 @@
   @apply pr-4;
 }
 
-.ui.message.header > .icon:not(.close) {
+.ui.message.header > .icon {
   @apply pr-16;
+}
+
+.orion-message {
+  @apply relative;
+  max-width: 600px;
+}
+
+.orion-message__close-icon {
+  @apply absolute right-0 cursor-pointer p-16 text-gray-700;
+  top: calc(50% - 26px);
 }


### PR DESCRIPTION
Adicionando os ícone de dismiss aqui.

Tentei usar o próprio ícone que o Semantic injeta, alterando o CSS, mas não consegui.

Acabei adicionando o ícone usando um wrapper, como @mairatma havia falado no PR anterior.

![2019-06-18 16 24 52](https://user-images.githubusercontent.com/1139664/59713422-d6469900-91e5-11e9-9e2e-2184fb05dc5a.gif)
