### PR TITLE
 feature(filter): Add keyboard interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://inloco.github.io/orion",
   "dependencies": {
     "classnames": "^2.2.6",
+    "keyboard-key": "^1.0.4",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.2",
     "react": "^16.6.0",

--- a/src/ClickOutside/index.js
+++ b/src/ClickOutside/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 
-const ClickOutside = ({ children, onClickOutside }) => {
+const ClickOutside = ({ as, children, onClickOutside, ...otherProps }) => {
   const ref = useRef()
 
   const handleClick = event => {
@@ -17,12 +17,22 @@ const ClickOutside = ({ children, onClickOutside }) => {
     }
   }, [onClickOutside])
 
-  return <div ref={ref}>{children}</div>
+  const ElementType = as
+  return (
+    <ElementType ref={ref} {...otherProps}>
+      {children}
+    </ElementType>
+  )
 }
 
 ClickOutside.propTypes = {
+  as: PropTypes.string,
   children: PropTypes.node,
   onClickOutside: PropTypes.func.isRequired
+}
+
+ClickOutside.defaultProps = {
+  as: 'div'
 }
 
 export default ClickOutside

--- a/src/Filter/Filter.test.js
+++ b/src/Filter/Filter.test.js
@@ -1,3 +1,4 @@
+import keyboardKey from 'keyboard-key'
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 
@@ -122,6 +123,23 @@ describe("when the filter's value changes", () => {
     beforeEach(() => {
       const { getByText } = renderResult
       fireEvent.click(getByText('Apply'))
+    })
+
+    it('should render the selected value in the trigger', () => {
+      const { queryByText } = renderResult
+      expect(queryByText(newValue)).toBeTruthy()
+    })
+
+    it('should call "onApply" with the new value', () => {
+      expect(onApply).toHaveBeenCalledWith(newValue)
+    })
+  })
+
+  describe('when the "ESC" key is pressed', () => {
+    beforeEach(() => {
+      const { getByPlaceholderText } = renderResult
+      const input = getByPlaceholderText('Input')
+      fireEvent.keyDown(input, { key: 'Escape', code: keyboardKey.Escape })
     })
 
     it('should render the selected value in the trigger', () => {

--- a/src/Filter/filter.css
+++ b/src/Filter/filter.css
@@ -1,19 +1,22 @@
-.filter-trigger {
+.ui.button.filter-trigger {
   @apply bg-white border border-gray-900-24 cursor-pointer rounded transition-default;
   @apply inline-flex h-32 items-center px-16 text-gray-800;
+  @apply outline-none;
   transition-property: background-color, color;
 }
 
-.filter-trigger:hover {
+.ui.button.filter-trigger:hover,
+.ui.button.filter-trigger:focus {
   @apply bg-gray-900-8;
 }
 
-.filter-trigger.active,
-.filter-trigger.selected {
+.ui.button.filter-trigger.active,
+.ui.button.filter-trigger.selected {
   @apply bg-space-100;
 }
 
-.filter-trigger.selected:hover {
+.ui.button.filter-trigger.selected:hover,
+.ui.button.filter-trigger.selected:focus {
   @apply bg-space-200;
 }
 

--- a/src/Filter/index.js
+++ b/src/Filter/index.js
@@ -1,7 +1,7 @@
 import cx from 'classnames'
+import keyboardKey from 'keyboard-key'
 import isEqual from 'lodash/isEqual'
 import isEmpty from 'lodash/isEmpty'
-import isNil from 'lodash/isNil'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 
@@ -27,14 +27,17 @@ const Filter = ({
 
   const [localValue, setLocalValue] = useState(value)
 
-  const isSelected = !isNil(value)
+  const isSelected = !isEmpty(value)
   const isPristine =
     (isEmpty(value) && isEmpty(localValue)) || isEqual(value, localValue)
 
-  const handleApply = () => {
+  const handleApply = event => {
     setValue(localValue)
     onApply && onApply(localValue)
     setOpen(false)
+
+    // Prevent form submission.
+    event.preventDefault()
   }
 
   const handleClear = () => {
@@ -42,14 +45,20 @@ const Filter = ({
     onClear && onClear()
   }
 
+  const handleKeyDown = event => {
+    if (keyboardKey.getCode(event) === keyboardKey.Escape) {
+      handleApply(event)
+    }
+  }
+
   const triggerClasses = cx('filter-trigger', {
     active: open,
     selected: isSelected
   })
   const trigger = (
-    <div className={triggerClasses} onClick={() => setOpen(!open)}>
+    <Button className={triggerClasses} onClick={() => setOpen(!open)}>
       {isSelected ? selectedText(value) : text}
-    </div>
+    </Button>
   )
 
   return (
@@ -59,9 +68,13 @@ const Filter = ({
       trigger={trigger}
       open={open}
       {...otherProps}>
-      <ClickOutside onClickOutside={handleApply}>
+      <ClickOutside
+        as="form"
+        onClickOutside={handleApply}
+        onKeyDown={handleKeyDown}
+        onSubmit={handleApply}>
         <div className="filter-content">
-          {open && children({ onChange: setLocalValue, value: localValue })}
+          {children({ onChange: setLocalValue, value: localValue })}
         </div>
         <div className="filter-buttons">
           <div className={cx({ invisible: isPristine })}>
@@ -79,8 +92,7 @@ const Filter = ({
             defaultProps: {
               primary: true,
               subtle: true,
-              type: 'submit',
-              onClick: handleApply
+              type: 'submit'
             }
           })}
         </div>


### PR DESCRIPTION
Interações de teclado no componente `Filter`. Agora é possível:
- Dar focus no filtro pelo teclado, e pressionar **Enter/Space** pra abrí-lo.
- Dar **Enter** em um campo dentro do filtro (ex.: input) faz o mesmo que clicar em `Apply`.
- Dar **Esc** em qualquer elemento do filtro faz o mesmo que clicar fora (que é o mesmo que clicar em `Apply` - mesmo comportamento do Airbnb, confirmei com Bruno/Cristiano).
- Usar **Tab** pra se movimentar entre os campos e botões dentro do filtro, e pressioná-los com **Enter/Space.**

**Entrando no filtro pelo teclado e usando Enter pra aplicar o resultado:**
![2019-06-20 10 41 04](https://user-images.githubusercontent.com/5216049/59854108-a19f2280-9348-11e9-8459-3cb45074d435.gif)

**Entrando no filtro pelo teclado e usando Enter pra pressionar o botão Clear:**
![2019-06-20 10 41 47](https://user-images.githubusercontent.com/5216049/59854103-9c41d800-9348-11e9-8014-1fd75b180f41.gif)
