### PR TITLE
fix(dropdown): Fix inline menu not having the expected height

### DIFF
--- a/src/Dropdown/DropdownKeepSelected/index.js
+++ b/src/Dropdown/DropdownKeepSelected/index.js
@@ -71,7 +71,7 @@ const DropdownKeepSelected = ({
     <SemanticDropdown
       options={options}
       onChange={handleChange}
-      value={value}
+      value={value || []}
       {...otherProps}
     />
   )

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -7,6 +7,7 @@ import { Dropdown as SemanticDropdown } from 'semantic-ui-react'
 import { Sizes, sizePropType } from '../utils/sizes'
 import DropdownItem from './DropdownItem'
 import DropdownKeepSelected from './DropdownKeepSelected'
+import useInlineMenuWrapper from './useInlineMenuWrapper'
 
 const DROPDOWN_ICON = {
   className: 'dropdown-icon',
@@ -43,7 +44,18 @@ const Dropdown = ({
   const ElementType = shouldKeepSelected
     ? DropdownKeepSelected
     : SemanticDropdown
-  return <ElementType {...dropdownProps} />
+  const element = <ElementType {...dropdownProps} />
+
+  const [wrapperRef, wrapperMargin] = useInlineMenuWrapper(options)
+  if (inlineMenu) {
+    return (
+      <div ref={wrapperRef} style={{ marginBottom: `${wrapperMargin}px` }}>
+        {element}
+      </div>
+    )
+  }
+
+  return element
 }
 
 Dropdown.propTypes = {

--- a/src/Dropdown/useInlineMenuWrapper.js
+++ b/src/Dropdown/useInlineMenuWrapper.js
@@ -1,0 +1,44 @@
+import _ from 'lodash'
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Semantic UI's dropdown has the dropdown menu with `position: absolute`.
+ * When the `inlineMenu` prop is enabled we need the menu to be rendered
+ * directly below the trigger, instead of inside of a popup box. In this
+ * case the menu shouldn't show up over elements that are below the dropdown,
+ * it needs to behave as if it was `position: static`. Unfortunately, we
+ * can't just make it static because of the structure of the other elements
+ * inside dropdown (trigger, input, labels, etc).
+ *
+ * To fix this, we add a wrapper around Semantic's dropdown and set the
+ * wrapper's margin bottom to the dropdown menu's height, making it act
+ * as if the menu was statically positioned. We update this height
+ * if the number of given options changes (which can happen when they
+ * come from an api call, for example).
+ */
+const useInlineMenuWrapper = options => {
+  const wrapperRef = useRef()
+  const optionsCountRef = useRef()
+  const [wrapperMargin, setWrapperMargin] = useState()
+
+  useEffect(() => {
+    const { current: wrapperEl } = wrapperRef
+    const { current: prevOptionsCount } = optionsCountRef
+    if (wrapperEl && options && prevOptionsCount !== options.length) {
+      const menuEl = wrapperEl.querySelector('.menu')
+
+      const { marginTop } = window.getComputedStyle(menuEl)
+      const marginTopNumber = _.toNumber(marginTop.split('px')[0])
+
+      const newMargin = menuEl.offsetHeight + marginTopNumber
+      if (newMargin !== wrapperMargin) {
+        setWrapperMargin(newMargin)
+      }
+      optionsCountRef.current = options.length
+    }
+  }, [options, wrapperMargin])
+
+  return [wrapperRef, wrapperMargin]
+}
+
+export default useInlineMenuWrapper

--- a/src/Dropdown/useInlineMenuWrapper.js
+++ b/src/Dropdown/useInlineMenuWrapper.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { useEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 
 /**
  * Semantic UI's dropdown has the dropdown menu with `position: absolute`.
@@ -21,7 +21,7 @@ const useInlineMenuWrapper = options => {
   const optionsCountRef = useRef()
   const [wrapperMargin, setWrapperMargin] = useState()
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const { current: wrapperEl } = wrapperRef
     const { current: prevOptionsCount } = optionsCountRef
     if (wrapperEl && options && prevOptionsCount !== options.length) {


### PR DESCRIPTION
Desculpem pelo tamanho do texto, não é trivial de explicar e eu queria deixar essa solução clara pra quem for revisar.

O dropdown do Semantic usa `position: absolute` no seu menu. Nada mais justo.

Porém, no Orion nós temos a opção de ter esse menu **inline**, com a nova prop `inlineMenu`. Nesse caso a gente não quer o menu dentro de uma caixinha popup que aparece por cima de qualquer conteúdo. Queremos os itens do menu diretamente abaixo do trigger do dropdown, tomando espaço normalmente, empurrando qualquer conteúdo abaixo dele, ou seja: `position: static`.

Infelizmente não podemos simplesmente torná-lo **static** por conta de como os outros elementos do dropdown (trigger, input, labels, etc) são renderizados.

Quebrei bastante a cabeça procurando uma solução aceitável pra esse caso. Opções que imaginei (algumas até implementei em parte antes de notar seus problemas):
1. **Setar `position: static` no menu e estilizá-lo pra funcionar corretamente dessa forma.** Infelizmente não é possível, por conta de como os outros elementos do dropdown (trigger, input, labels, etc) são renderizados. O menu sempre acaba dentro da borda do trigger. Tentei movê-la pra algum outro elemento interior, mas não funciona, especialmente em casos de multiple selection, pois o trigger pode crescer verticalmente pra acomodar mais labels ou o input.
2. **Não usar `Dropdown`.** Nenhum outro componente existente possui certas funcionalidades complexas que `Dropdown` nos dá, e que precisaremos nesses componentes com menu inline. Exemplos: multiple selection, keyboard selections, search, e vários outras, combinadas entre si. Daria muito mais trabalho, tanto pra desenvolver quanto pra manter, e ainda correria o risco de ter diferenças de comportamento com dropdowns sem `inlineMenu`.
3. **Usar `Dropdown`, mas reescrevendo o `Dropdown.Menu`, repassando como children.** Mas isso também nos faz perder todas as funcionalidades acima, que só funcionam automaticamente quando deixamos o `Dropdown` montar o próprio menu.
4. **Usar `Dropdown`, mas reescrevendo o trigger, usando apenas o menu.** Mesmo problema acima.
5. **Usar dois `Dropdown`, um por cima do outro. O primeiro apenas com o trigger, o segundo com o menu com `position: static`, sincronizando o value de ambos.** Essa foi promissora, permitiu deixar o menu fora da borda e parecia manter todas as funcionalidades. Mas notei que na verdade não seria possível manter a seleção por teclado (`Dropdown` não tem props pra controlar isso por fora) nem search (apenas controlando suas props). Teria que ter bastante código extra pra cobrir essas features que faltavam e ainda poderia ter mais que ainda não notei.
6. **Adicionar um wrapper do `Dropdown`, atualizando seu height pra ser o height do trigger + height do menu.** Uhuuuuuu, funcionou 100%, e com menos código do que todas as outras opções acima precisariam pra funcionar parcialmente 🎉 🎉 . Infelizmente demorei pra pensar nisso.

Explicando melhor a opção que implementei: basicamente estou apenas colocando um wrapper ao redor do `Dropdown` quando ele for `inlineMenu`, e setando o seu `margin-bottom` pra o tamanho final do menu renderizado. Atualizo esse `margin-bottom` caso a quantidade de options mudar (importante especialmente quando vierem de alguma api).

No storybook isso não fica muito visível (por isso não notei quando adicionei o `inlineMenu`), mas pra poder mostrar aqui no pr eu adicionei uma borda ao redor do wrapper da story, mostrando o tamanho do wrapper com o dropdown dentro.

**Antes (menu fica de fora do height do pai)**
<img width="419" alt="Screen Shot 2019-06-27 at 10 36 21 AM" src="https://user-images.githubusercontent.com/5216049/60272340-58ac1880-98ca-11e9-8158-8671fcf2c5e9.png">

**Depois (menu incluso no height, que muda caso ele mude de tamanho)**
![2019-06-27 10 35 36](https://user-images.githubusercontent.com/5216049/60272489-a6c11c00-98ca-11e9-8975-16273617de87.gif)

**Usado dentro de Filter**
Notem que o tamanho do popup do Filter depende do height do dropdown.

<img width="324" alt="Screen Shot 2019-06-27 at 10 37 12 AM" src="https://user-images.githubusercontent.com/5216049/60272546-c8ba9e80-98ca-11e9-9beb-d1868d31ae57.png">

