### PR TITLE
fix(box-shadow): Make focus = active

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
-    "@inloco/atomic-bomb": "^1.0.4",
+    "@inloco/atomic-bomb": "^1.0.5",
     "@storybook/addon-actions": "^5.1.8",
     "@storybook/addon-knobs": "^5.1.8",
     "@storybook/addons": "^5.1.8",

--- a/src/Checkbox/checkbox.css
+++ b/src/Checkbox/checkbox.css
@@ -19,12 +19,12 @@
   content: '';
 }
 
-.ui.checkbox input[type='checkbox'] ~ label:hover:before,
-.ui.checkbox input[type='checkbox']:focus ~ label:before {
+.ui.checkbox input[type='checkbox'] ~ label:hover:before {
   @apply bg-gray-900-8;
 }
 
-.ui.checkbox input[type='checkbox'] ~ label:active:before {
+.ui.checkbox input[type='checkbox'] ~ label:active:before,
+.ui.checkbox input[type='checkbox']:focus ~ label:before {
   @apply bg-gray-900-16;
 }
 
@@ -36,11 +36,7 @@
 .ui.checkbox:not(.disabled) input[type='checkbox']:checked ~ label:hover:before,
 .ui.checkbox:not(.disabled)
   input[type='checkbox']:indeterminate
-  ~ label:hover:before,
-.ui.checkbox:not(.disabled) input[type='checkbox']:checked:focus ~ label:before,
-.ui.checkbox:not(.disabled)
-  input[type='checkbox']:indeterminate:focus
-  ~ label:before {
+  ~ label:hover:before {
   @apply bg-wave-600;
 }
 
@@ -49,7 +45,11 @@
   ~ label:active:before,
 .ui.checkbox:not(.disabled)
   input[type='checkbox']:indeterminate
-  ~ label:active:before {
+  ~ label:active:before,
+.ui.checkbox:not(.disabled) input[type='checkbox']:checked:focus ~ label:before,
+.ui.checkbox:not(.disabled)
+  input[type='checkbox']:indeterminate:focus
+  ~ label:before {
   @apply bg-wave-700;
 }
 

--- a/src/Dropdown/dropdown.css
+++ b/src/Dropdown/dropdown.css
@@ -146,12 +146,12 @@
   @apply bg-gray-900-8;
 }
 
-.ui.dropdown.selection:hover,
-.ui.dropdown.selection:focus {
+.ui.dropdown.selection:hover {
   @apply shadow-field-hover;
 }
 
-.ui.dropdown.selection:active {
+.ui.dropdown.selection:active,
+.ui.dropdown.selection:focus {
   @apply shadow-field-active;
 }
 
@@ -177,12 +177,12 @@
   @apply border-magenta-500;
 }
 
-.ui.dropdown.error.selection:hover,
-.ui.dropdown.error.selection:focus {
+.ui.dropdown.error.selection:hover {
   @apply shadow-error-field-hover;
 }
 
-.ui.dropdown.error.selection:active {
+.ui.dropdown.error.selection:active,
+.ui.dropdown.error.selection:focus {
   @apply shadow-error-field-active;
 }
 
@@ -190,11 +190,11 @@
   @apply border-yellow-500;
 }
 
-.ui.dropdown.warning.selection:hover,
-.ui.dropdown.warning.selection:focus {
+.ui.dropdown.warning.selection:hover {
   @apply shadow-warning-field-hover;
 }
 
-.ui.dropdown.warning.selection:active {
+.ui.dropdown.warning.selection:active,
+.ui.dropdown.warning.selection:focus {
   @apply shadow-warning-field-active;
 }

--- a/src/Input/input.css
+++ b/src/Input/input.css
@@ -13,12 +13,12 @@
   @apply bg-gray-900-8 pointer-events-none;
 }
 
-.ui.input > input:hover,
-.ui.input > input:focus {
+.ui.input > input:hover {
   @apply shadow-field-hover;
 }
 
-.ui.input > input:active {
+.ui.input > input:active,
+.ui.input > input:focus {
   @apply shadow-field-active;
 }
 
@@ -31,12 +31,12 @@
   @apply border-magenta-500;
 }
 
-.ui.input.error > input:hover,
-.ui.input.error > input:focus {
+.ui.input.error > input:hover {
   @apply shadow-error-field-hover;
 }
 
-.ui.input.error > input:active {
+.ui.input.error > input:active,
+.ui.input.error > input:focus {
   @apply shadow-error-field-active;
 }
 
@@ -45,12 +45,12 @@
   @apply border-yellow-500;
 }
 
-.ui.input.warning > input:hover,
-.ui.input.warning > input:focus {
+.ui.input.warning > input:hover {
   @apply shadow-warning-field-hover;
 }
 
-.ui.input.warning > input:active {
+.ui.input.warning > input:active,
+.ui.input.warning > input:focus {
   @apply shadow-warning-field-active;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,10 +1094,10 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
-"@inloco/atomic-bomb@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@inloco/atomic-bomb/-/atomic-bomb-1.0.4.tgz#5aff88e97d9aca79e0dec183f74bfd78dc9009a0"
-  integrity sha512-DqmFpXqRvIfWF7paEdeLUinAb0oFI3zsx3vhSRfAvKTtKZxNtfyFLz/VA54MVC4lgy2GfFYbp+hVG+YzIMdCFA==
+"@inloco/atomic-bomb@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@inloco/atomic-bomb/-/atomic-bomb-1.0.5.tgz#b9bc48940bf7ae8ba1f9cb0aa63ba601e715e0f2"
+  integrity sha512-Td8bt62tfE/sLQKBA0ywgULKWYDf/H6tFuZxbhr+LWj55HeLwCOpb7jFV8Vyrg37JV5idVTDcmsFUTK2isBY0A==
   dependencies:
     color "^3.1.2"
     pretty-quick "^1.11.0"


### PR DESCRIPTION
@mairatma Bruno mudou de idéia, veio aqui na mesa, e disse que era melhor que o focus = active.

Expliquei a ele da questão do checkbox, mas ele mesmo assim achou melhor.

Também revisei com ele a quantidade de opacidade no hover para os estados de warning e error, e aumentamos um pouco. Fiz isto direto no atomic-bomb.

