### PR TITLE
 fix(checkbox): Fix checkbox styles and add space between checkboxes

### DIFF
--- a/src/Checkbox/Checkbox.stories.js
+++ b/src/Checkbox/Checkbox.stories.js
@@ -16,3 +16,10 @@ storiesOf('Checkbox', module)
       />
     </React.Fragment>
   ))
+  .add('multiple', () => (
+    <React.Fragment>
+      <Checkbox label="First" />
+      <Checkbox label="Second" />
+      <Checkbox label="Third" />
+    </React.Fragment>
+  ))

--- a/src/Checkbox/checkbox.css
+++ b/src/Checkbox/checkbox.css
@@ -83,3 +83,11 @@
 .ui.checkbox.disabled input[type='checkbox'] ~ label:after {
   @apply text-gray-800;
 }
+
+/**
+ * Space between checkboxes
+ */
+
+.ui.checkbox + .ui.checkbox {
+  @apply mt-16;
+}

--- a/src/Checkbox/checkbox.css
+++ b/src/Checkbox/checkbox.css
@@ -1,5 +1,5 @@
 .ui.checkbox {
-  @apply relative;
+  @apply my-2 relative;
 }
 
 .ui.checkbox input[type='checkbox'] {
@@ -9,7 +9,7 @@
 }
 
 .ui.checkbox input[type='checkbox'] ~ label {
-  @apply block cursor-pointer pl-24;
+  @apply block cursor-pointer text-base text-gray-900 pl-24;
   line-height: 16px;
 }
 


### PR DESCRIPTION
Uns estilos novos pra `label` no atomic bomb afetaram o checkbox. Consertei aqui e aproveitei pra adicionar o espaçamento default entre checkboxes, que estava faltando.

**Antes**
<img width="92" alt="Screen Shot 2019-06-28 at 11 12 44 AM" src="https://user-images.githubusercontent.com/5216049/60348313-afcaef80-9995-11e9-80bb-070050bbe7c5.png">

**Depois**
<img width="98" alt="Screen Shot 2019-06-28 at 11 10 56 AM" src="https://user-images.githubusercontent.com/5216049/60348210-76927f80-9995-11e9-8e88-18af24cb5316.png">
