### PR TITLE
fix(notificationCenter): Fix prop types warnings when strings are given

### DIFF
--- a/src/NotificationCenter/index.js
+++ b/src/NotificationCenter/index.js
@@ -17,12 +17,12 @@ const NotificationCenter = ({ defaults, ...props }) => {
 
 NotificationCenter.propTypes = {
   defaults: PropTypes.shape({
-    errorTitle: PropTypes.object,
-    errorMessage: PropTypes.object,
-    successTitle: PropTypes.object,
-    successMessage: PropTypes.object,
-    warningTitle: PropTypes.object,
-    warningMessage: PropTypes.object
+    errorTitle: PropTypes.any,
+    errorMessage: PropTypes.any,
+    successTitle: PropTypes.any,
+    successMessage: PropTypes.any,
+    warningTitle: PropTypes.any,
+    warningMessage: PropTypes.any
   })
 }
 


### PR DESCRIPTION
Essas keys da prop `defaults` também aceitam outros tipos, como string. Estava dando warning quando usada assim.

Pra evitar copiar a lógica toda do semantic pra cada key dessas, podemos deixar cada uma como `any`. O semantic vai fazer a validação necessária pra cada uma, a gente só precisa detalhar que essas são as keys aceitas na prop `defaults`.