### PR TITLE
feature(layout): Add Layout.Center component

### DIFF
--- a/packages/orion/src/Layout/LayoutCenter/index.js
+++ b/packages/orion/src/Layout/LayoutCenter/index.js
@@ -1,0 +1,30 @@
+import _ from 'lodash'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const LayoutCenter = ({
+  as: ElementType,
+  className,
+  children,
+  ...otherProps
+}) => {
+  const classes = cx('layout-center', className)
+  return (
+    <ElementType className={classes} {...otherProps}>
+      <div className="layout-center-content">{children}</div>
+    </ElementType>
+  )
+}
+
+LayoutCenter.propTypes = {
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  className: PropTypes.string,
+  children: PropTypes.node
+}
+
+LayoutCenter.defaultProps = {
+  as: 'div'
+}
+
+export default LayoutCenter

--- a/packages/orion/src/Layout/LayoutMain/index.js
+++ b/packages/orion/src/Layout/LayoutMain/index.js
@@ -3,18 +3,15 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const LayoutMain = ({ className, children, ...otherProps }) => {
+import LayoutCenter from '../LayoutCenter'
+
+const LayoutMain = ({ className, ...otherProps }) => {
   const classes = cx('layout-main', className)
-  return (
-    <main className={classes} {...otherProps}>
-      <div className="layout-main-content">{children}</div>
-    </main>
-  )
+  return <LayoutCenter as="main" className={classes} {...otherProps} />
 }
 
 LayoutMain.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node
+  className: PropTypes.string
 }
 
 export default LayoutMain

--- a/packages/orion/src/Layout/LayoutTopbar/index.js
+++ b/packages/orion/src/Layout/LayoutTopbar/index.js
@@ -3,17 +3,16 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import LayoutCenter from '../LayoutCenter'
 import Logo from '../../Logo'
 
 const LayoutTopbar = ({ className, children, logo, ...otherProps }) => {
   const classes = cx('layout-topbar', className)
   return (
-    <div className={classes} {...otherProps}>
-      <div className="layout-topbar-content">
-        {logo || <Logo />}
-        {children}
-      </div>
-    </div>
+    <LayoutCenter className={classes} {...otherProps}>
+      {logo || <Logo />}
+      {children}
+    </LayoutCenter>
   )
 }
 

--- a/packages/orion/src/Layout/index.js
+++ b/packages/orion/src/Layout/index.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import LayoutCenter from './LayoutCenter'
 import LayoutMain from './LayoutMain'
 import LayoutTopbar from './LayoutTopbar'
 
@@ -20,6 +21,7 @@ Layout.propTypes = {
   children: PropTypes.node
 }
 
+Layout.Center = LayoutCenter
 Layout.Main = LayoutMain
 Layout.Topbar = LayoutTopbar
 

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -2,26 +2,29 @@
   @apply bg-gray-50 flex flex-col min-h-screen items-center relative;
 }
 
-.ui.layout .layout-topbar {
-  @apply fixed top-0 left-0 z-50;
-  @apply flex flex-shrink-0 items-center justify-center h-48 w-full bg-white;
-  @apply border-b-1 border-gray-900-16;
+.ui.layout .layout-center {
+  @apply flex justify-center w-full;
 }
 
-.ui.layout .layout-topbar-content {
-  @apply flex items-center mx-24 w-full;
+.ui.layout .layout-center-content {
+  @apply mx-24 w-full;
   max-width: 1024px;
 }
 
-.ui.layout .layout-topbar-content .ui.menu {
+.ui.layout .layout-topbar {
+  @apply fixed top-0 left-0 z-50;
+  @apply flex-shrink-0 items-center h-48 bg-white;
+  @apply border-b-1 border-gray-900-16;
+}
+
+.ui.layout .layout-topbar > .layout-center-content {
+  @apply flex items-center;
+}
+
+.ui.layout .layout-topbar .ui.menu {
   @apply flex-1 ml-40;
 }
 
 .ui.layout .layout-main {
-  @apply flex flex-1 justify-center py-24 w-full mt-48;
-}
-
-.ui.layout .layout-main-content {
-  @apply mx-24 w-full;
-  max-width: 1024px;
+  @apply flex-1 py-24 mt-48;
 }


### PR DESCRIPTION
A lógica de centralização do Layout da gente não é tão trivial (margin mínima, width máximo, centralizado, etc) e já estava duplicada em dois lugares (`Layout.Main` e `Layout.Topbar`). Agora vou precisar da mesma lógica novamente pra um header especial lá no `inloco-frontend`, então achei melhor aproveitar pra criar um componente que abstraia essa lógica. Estou chamando ele de `Layout.Center`.

Nada mudou visualmente, só extraí essa lógica e estou exportando esse novo componente.