### PR TITLE
fix(buttonAndFilter): Fix spacings for filters and subtle buttons

### DIFF
--- a/packages/orion/src/Button/button.css
+++ b/packages/orion/src/Button/button.css
@@ -76,7 +76,11 @@
 /* Subtle */
 
 .ui.button.subtle {
-  @apply bg-transparent;
+  @apply bg-transparent h-auto;
+}
+
+.ui.button.subtle.icon {
+  @apply h-24 w-24;
 }
 
 /* Subtle Primary */

--- a/packages/orion/src/Filter/filter.css
+++ b/packages/orion/src/Filter/filter.css
@@ -31,7 +31,7 @@
 }
 
 .ui.popup.filter .filter-content {
-  @apply p-8;
+  @apply p-8 pb-24;
 }
 
 .ui.popup.filter .filter-buttons {


### PR DESCRIPTION
O botão subtle não deve ter nenhum padding, pois ele é praticamente um link. O padding, herdado dos outros botões, estava atrapalhando o espaçamento em Filter. 

**Antes - Button subtle**

<img width="162" alt="Screen Shot 2019-07-03 at 2 41 22 PM" src="https://user-images.githubusercontent.com/5216049/60613177-ba73f300-9da0-11e9-8768-2811a2b85472.png">

**Depois - Button subtle**

<img width="170" alt="Screen Shot 2019-07-03 at 2 41 06 PM" src="https://user-images.githubusercontent.com/5216049/60613176-ba73f300-9da0-11e9-856e-1ebc3c171841.png">

**Antes - Filter**
<img width="256" alt="Screen Shot 2019-07-03 at 2 41 31 PM" src="https://user-images.githubusercontent.com/5216049/60613178-ba73f300-9da0-11e9-894b-434036ce448e.png">

**Depois - Filter**
<img width="256" alt="Screen Shot 2019-07-03 at 2 44 36 PM" src="https://user-images.githubusercontent.com/5216049/60613353-19d20300-9da1-11e9-9e6b-dcbcf0517faf.png">
