### PR TITLE
feature(dropdown): Enable deburr by default

### DIFF
--- a/packages/orion/src/Dropdown/Dropdown.stories.js
+++ b/packages/orion/src/Dropdown/Dropdown.stories.js
@@ -9,7 +9,7 @@ import { sizeKnob } from '../utils/stories'
 const developerOptions = [
   { text: 'Francisco Gileno', value: 1 },
   { text: 'Rafael Nunes', value: 2 },
-  { text: 'Maira Bello', value: 3 }
+  { text: 'Maíra Bello', value: 3 }
 ]
 
 storiesOf('Dropdown', module)

--- a/packages/orion/src/Dropdown/index.js
+++ b/packages/orion/src/Dropdown/index.js
@@ -75,6 +75,7 @@ Dropdown.propTypes = {
 }
 
 Dropdown.defaultProps = {
+  deburr: true,
   icon: DROPDOWN_ICON,
   size: Sizes.DEFAULT
 }


### PR DESCRIPTION
Vamos ignorar acentos no search do dropdown automaticamente. É fácil esquecer de ligar essa prop, ou até mesmo saber que ela existe (experiência própria no 4apps).

**Antes:**
<img width="268" alt="Screen Shot 2019-07-08 at 11 36 47 AM" src="https://user-images.githubusercontent.com/5216049/60818795-b9faa400-a174-11e9-8601-207895728048.png">

**Depois:**
<img width="280" alt="Screen Shot 2019-07-08 at 11 36 37 AM" src="https://user-images.githubusercontent.com/5216049/60818794-b9faa400-a174-11e9-81e2-912cb079fc78.png">

