### PR TITLE
fix(Dropdown): height 24px instead of 32px for small size

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -150,6 +150,10 @@
   @apply bg-white border border-gray-900-24 rounded;
 }
 
+.ui.dropdown.selection.small {
+  @apply min-h-32;
+}
+
 .ui.dropdown.selection.disabled {
   @apply bg-gray-900-8;
 }

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -19,7 +19,7 @@
 }
 
 .ui.dropdown.small {
-  @apply min-h-32;
+  @apply min-h-24;
 }
 
 .ui.dropdown .text {


### PR DESCRIPTION
Revisando com Bruno este dropdown, ele me disse que o height do dropdown small deveria ser 24px em vez de 32px.

Antes:
![image](https://user-images.githubusercontent.com/1139664/61811645-4d400480-ae18-11e9-8f5f-122b132a80a6.png)

Depois:
![image](https://user-images.githubusercontent.com/1139664/61811659-592bc680-ae18-11e9-9abd-c18afd5ccc51.png)
