### PR TITLE
fix(filter): Reset local value when opening the filter

### DIFF
--- a/packages/orion/src/Filter/Filter.test.js
+++ b/packages/orion/src/Filter/Filter.test.js
@@ -88,6 +88,25 @@ describe('when a value is given', () => {
       )
       expect(queryByText(newValue)).toBeTruthy()
     })
+
+    it("should pass this new given value to the filter's contents", () => {
+      const { getByText, getByPlaceholderText, rerender } = render(
+        <Filter text="Open" value={value}>
+          {childFn}
+        </Filter>
+      )
+
+      const newValue = 'New controlled value'
+      rerender(
+        <Filter text="Open" value={newValue}>
+          {childFn}
+        </Filter>
+      )
+
+      fireEvent.click(getByText(newValue))
+      const input = getByPlaceholderText('Input')
+      expect(input.value).toEqual(newValue)
+    })
   })
 })
 

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -58,12 +58,19 @@ const Filter = ({
     onChange && onChange(newLocalValue)
   }
 
+  const handleTriggerClick = () => {
+    if (!open) {
+      setLocalValue(value)
+    }
+    setOpen(!open)
+  }
+
   const triggerClasses = cx('filter-trigger', {
     active: open,
     selected: isSelected
   })
   const trigger = (
-    <Button className={triggerClasses} onClick={() => setOpen(!open)}>
+    <Button className={triggerClasses} onClick={handleTriggerClick}>
       {isSelected ? selectedText(value) : text}
     </Button>
   )


### PR DESCRIPTION
O valor passado para o conteúdo do `Filter` é sempre o `localValue`.
O valor que é mostrado no trigger é o valor atualmente selecionado, `value`.

Notei um bug que ocorre caso esse valor selecionado seja mudado por fora do filtro (modificado por algum pai, que repassa o novo valor pela prop `value`, por exemplo). Nesse caso, o texto do botão era modificado corretamente, porém o conteúdo do filtro continuava usando `localValue`, e perdia essa atualização.

Corrigi isso nesse pr da seguinte forma: ao abrir o filtro, sempre resetamos o `localValue` para o `value` atual. Assim o conteúdo sempre terá o valor atualizado.

**Antes**
![2019-08-06 13 15 48](https://user-images.githubusercontent.com/5216049/62557201-e0cbf900-b84c-11e9-9ed3-165ecfcbf8ff.gif)

**Depois**
![2019-08-06 13 16 09](https://user-images.githubusercontent.com/5216049/62557202-e1648f80-b84c-11e9-975c-487915bd2ad6.gif)
