### PR TITLE
feature(datepicker): Automatically convert given dates to moment objects

### DIFF
--- a/packages/orion/package.json
+++ b/packages/orion/package.json
@@ -31,6 +31,7 @@
     "classnames": "^2.2.6",
     "keyboard-key": "^1.0.4",
     "lodash": "^4.17.14",
+    "moment": "^2.24.0",
     "prop-types": "^15.6.2",
     "react": "^16.6.0",
     "react-dates": "^20.2.5",

--- a/packages/orion/src/Datepicker/index.js
+++ b/packages/orion/src/Datepicker/index.js
@@ -1,3 +1,4 @@
+import { toMoment } from '../utils/datetime'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { DayPickerSingleDateController } from 'react-dates'
@@ -21,7 +22,7 @@ const Datepicker = ({
     <div className="ui datepicker">
       <ReactDatesDatepicker
         as={DayPickerSingleDateController}
-        date={date}
+        date={toMoment(date)}
         onDateChange={handleChange}
         {...otherProps}
       />

--- a/packages/orion/src/RangedDatepicker/RangedDatepicker.stories.js
+++ b/packages/orion/src/RangedDatepicker/RangedDatepicker.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
-import { number, withKnobs } from '@storybook/addon-knobs'
+import { number, withKnobs, text } from '@storybook/addon-knobs'
 
 import { RangedDatepicker } from '../'
 
@@ -12,9 +12,12 @@ export const actions = {
 storiesOf('RangedDatepicker', module)
   .addDecorator(withKnobs)
   .add('basic', () => {
+    const startDate = text('Start Date') || null
+    const endDate = text('End Date') || null
     return (
       <RangedDatepicker
         numberOfMonths={number('Number of months', 1)}
+        dates={startDate || endDate ? { startDate, endDate } : null}
         {...actions}
       />
     )

--- a/packages/orion/src/RangedDatepicker/index.js
+++ b/packages/orion/src/RangedDatepicker/index.js
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { DayPickerRangeController } from 'react-dates'
 
 import ReactDatesDatepicker from '../Datepicker/ReactDatesDatepicker'
+import { toMoment } from '../utils/datetime'
 
 const RangedDatepicker = ({
   dates: dateProp,
@@ -31,8 +32,8 @@ const RangedDatepicker = ({
     <div className="ui ranged-datepicker">
       <ReactDatesDatepicker
         as={DayPickerRangeController}
-        startDate={_.get(dates, 'startDate')}
-        endDate={_.get(dates, 'endDate')}
+        startDate={toMoment(_.get(dates, 'startDate'))}
+        endDate={toMoment(_.get(dates, 'endDate'))}
         onDatesChange={handleDatesChange}
         focusedInput={focusedInput || 'startDate'}
         onFocusChange={handleFocusChange}

--- a/packages/orion/src/utils/datetime.js
+++ b/packages/orion/src/utils/datetime.js
@@ -1,0 +1,3 @@
+import moment from 'moment'
+
+export const toMoment = date => date && moment(date)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10058,7 +10058,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@>=1.6.0:
+moment@>=1.6.0, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
Os componentes do `react-dates` só aceitam objetos do Moment nas props de datas. Não aceitam strings nem timestamps.

Estou adicionando uma conversão automática pra o moment em nossos wrappers. Já precisei em alguns momentos, isso vai ajudar bastante.