### PR TITLE
feature(loading): Add prop for determining if the loader is inline or not

### DIFF
--- a/packages/orion/src/Loading/Loading.stories.js
+++ b/packages/orion/src/Loading/Loading.stories.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs } from '@storybook/addon-knobs'
+import { boolean, withKnobs } from '@storybook/addon-knobs'
 
 import { Loading } from '../'
+import { sizeKnob } from '../utils/stories'
 
 storiesOf('Loading', module)
   .addDecorator(withKnobs)
-  .add('default', () => {
-    return <Loading />
-  })
-  .add('small', () => {
-    return <Loading size="small" />
-  })
+  .add('Default', () => (
+    <div className="h-screen -m-8">
+      <Loading size={sizeKnob()} inline={boolean('Inline', false)} />
+    </div>
+  ))

--- a/packages/orion/src/Loading/index.js
+++ b/packages/orion/src/Loading/index.js
@@ -6,20 +6,26 @@ import Lottie from 'react-lottie'
 import { Sizes, sizePropType } from '../utils/sizes'
 import animationData from './animationData'
 
-const Loading = ({ className, size, ...otherProps }) => (
-  <div className={cx('ui loading-spinner', className, size)} {...otherProps}>
-    <Lottie
-      options={{
-        loop: true,
-        autoplay: true,
-        animationData
-      }}
-    />
-  </div>
-)
+const Loading = ({ className, inline, size, ...otherProps }) => {
+  const classes = cx('ui loading-spinner', className, size, {
+    'loading-spinner-inline': inline
+  })
+  return (
+    <div className={classes} {...otherProps}>
+      <Lottie
+        options={{
+          loop: true,
+          autoplay: true,
+          animationData
+        }}
+      />
+    </div>
+  )
+}
 
 Loading.propTypes = {
   className: PropTypes.string,
+  inline: PropTypes.bool,
   size: sizePropType
 }
 

--- a/packages/orion/src/Loading/loading.css
+++ b/packages/orion/src/Loading/loading.css
@@ -1,7 +1,11 @@
 .ui.loading-spinner {
-  @apply w-48;
+  @apply h-full mx-auto w-48;
 }
 
 .ui.loading-spinner.small {
   width: 20px;
+}
+
+.ui.loading-spinner-inline {
+  @apply h-auto m-0;
 }


### PR DESCRIPTION
Estávamos sempre deixando o componente `Loading` inline, mas frequentemente vamos querê-lo centralizado no pai. Deixei esse comportamento como o default e adicionei uma prop `inline` pra o comportamento anterior.

Como ninguém (acredito) ainda usava, é tranquilo mudar esse comportamento default, e achei que a prop ficou mais clara sendo a de `inline`.

![2019-08-12 14 26 35](https://user-images.githubusercontent.com/5216049/62884581-4e749b00-bd0d-11e9-83ef-50be63b14372.gif)
