### PR TITLE
feature(filter): Add onOpen and onClose props to Filter

### DIFF
--- a/packages/orion/src/Filter/Filter.stories.js
+++ b/packages/orion/src/Filter/Filter.stories.js
@@ -8,7 +8,9 @@ import { Dropdown, Filter, Input } from '../'
 const actions = {
   onChange: action('onChange'),
   onApply: action('onApply'),
-  onClear: action('onClear')
+  onClear: action('onClear'),
+  onOpen: action('onOpen'),
+  onClose: action('onClose')
 }
 
 storiesOf('Filter', module)

--- a/packages/orion/src/Filter/Filter.test.js
+++ b/packages/orion/src/Filter/Filter.test.js
@@ -12,15 +12,35 @@ const childFn = ({ onChange, value }) => (
   />
 )
 
-it('should open/close the popup when the trigger is clicked', () => {
-  const triggerText = 'Open'
-  const { getByText } = render(<Filter text={triggerText}>{childFn}</Filter>)
+describe('when the trigger is clicked', () => {
+  it('should open/close the popup', () => {
+    const triggerText = 'Open'
+    const { getByText } = render(<Filter text={triggerText}>{childFn}</Filter>)
 
-  fireEvent.click(getByText(triggerText))
-  expect(getByText(triggerText)).toHaveClass('active')
+    fireEvent.click(getByText(triggerText))
+    expect(getByText(triggerText)).toHaveClass('active')
 
-  fireEvent.click(getByText(triggerText))
-  expect(getByText(triggerText)).not.toHaveClass('active')
+    fireEvent.click(getByText(triggerText))
+    expect(getByText(triggerText)).not.toHaveClass('active')
+  })
+
+  it('should call the "onOpen" and "onClose"', () => {
+    const onOpen = jest.fn()
+    const onClose = jest.fn()
+    const triggerText = 'Open'
+    const { getByText } = render(
+      <Filter onClose={onClose} onOpen={onOpen} text={triggerText}>
+        {childFn}
+      </Filter>
+    )
+
+    fireEvent.click(getByText(triggerText))
+    expect(onOpen).toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.click(getByText(triggerText))
+    expect(onClose).toHaveBeenCalled()
+  })
 })
 
 describe('when an initial value is given', () => {
@@ -113,18 +133,21 @@ describe('when a value is given', () => {
 describe("when the filter's value changes", () => {
   const newValue = 'New Value'
   let onChange
+  let onClose
   let onApply
   let onClear
   let renderResult
 
   beforeEach(() => {
     onChange = jest.fn()
+    onClose = jest.fn()
     onApply = jest.fn()
     onClear = jest.fn()
     renderResult = render(
       <Filter
         text="Open"
         onChange={onChange}
+        onClose={onClose}
         onApply={onApply}
         onClear={onClear}>
         {childFn}
@@ -161,6 +184,10 @@ describe("when the filter's value changes", () => {
 
     it('should call "onApply" with the new value', () => {
       expect(onApply).toHaveBeenCalledWith(newValue)
+    })
+
+    it('should call "onClose"', () => {
+      expect(onClose).toHaveBeenCalled()
     })
   })
 

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -13,9 +13,11 @@ const Filter = ({
   className,
   extraFooterContent,
   initialValue,
+  onApply,
   onChange,
   onClear,
-  onApply,
+  onClose,
+  onOpen,
   selectedText,
   text,
   value: propValue,
@@ -35,7 +37,9 @@ const Filter = ({
   const handleApply = event => {
     setValue(localValue)
     onApply && onApply(localValue)
+
     setOpen(false)
+    onClose && onClose()
 
     // Prevent form submission.
     event.preventDefault()
@@ -59,8 +63,11 @@ const Filter = ({
   }
 
   const handleTriggerClick = () => {
-    if (!open) {
+    if (open) {
+      onClose && onClose()
+    } else {
       setLocalValue(value)
+      onOpen && onOpen()
     }
     setOpen(!open)
   }
@@ -127,9 +134,11 @@ Filter.propTypes = {
   className: PropTypes.string,
   extraFooterContent: PropTypes.node,
   initialValue: PropTypes.any,
+  onApply: PropTypes.func,
+  onClose: PropTypes.func,
   onChange: PropTypes.func,
   onClear: PropTypes.func,
-  onApply: PropTypes.func,
+  onOpen: PropTypes.func,
   selectedText: PropTypes.func,
   text: PropTypes.string.isRequired,
   value: PropTypes.any


### PR DESCRIPTION
Não podemos reusar apenas essas funções do `Popup` do semantic, pois elas não funcionam bem no caso do `Filter` (que usa o `Popup` com a prop `open` como controlled).

