### PR TITLE
fix(button): Fix color of custom icons inside buttons

### DIFF
--- a/packages/orion/src/Button/button.css
+++ b/packages/orion/src/Button/button.css
@@ -49,6 +49,10 @@
   @apply bg-wave-500 text-white;
 }
 
+.ui.button.primary svg.icon {
+  @apply fill-white;
+}
+
 .ui.button.primary:hover,
 .ui.button.primary:focus {
   @apply bg-wave-600;
@@ -89,13 +93,26 @@
   @apply text-wave-500;
 }
 
+.ui.button.subtle.primary svg.icon {
+  @apply fill-wave-500;
+}
+
 .ui.button.subtle.primary:hover,
 .ui.button.subtle.primary:focus {
   @apply bg-transparent text-wave-600;
 }
 
+.ui.button.subtle.primary:hover svg.icon,
+.ui.button.subtle.primary:focus svg.icon {
+  @apply fill-wave-600;
+}
+
 .ui.button.subtle.primary:active {
   @apply bg-transparent text-wave-700;
+}
+
+.ui.button.subtle.primary:active svg.icon {
+  @apply fill-wave-700;
 }
 
 /* Subtle Secondary */
@@ -104,19 +121,36 @@
   @apply text-gray-700;
 }
 
+.ui.button.subtle.secondary svg.icon {
+  @apply fill-gray-700;
+}
+
 .ui.button.subtle.secondary:hover,
 .ui.button.subtle.secondary:focus {
   @apply bg-transparent text-gray-800;
+}
+
+.ui.button.subtle.secondary:hover svg.icon,
+.ui.button.subtle.secondary:focus svg.icon {
+  @apply fill-gray-800;
 }
 
 .ui.button.subtle.secondary:active {
   @apply bg-transparent text-gray-900;
 }
 
+.ui.button.subtle.secondary:active svg.icon {
+  @apply fill-gray-900;
+}
+
 /* Ghost */
 
 .ui.button.ghost {
   @apply bg-white text-wave-500 border border-wave-500;
+}
+
+.ui.button.ghost svg.icon {
+  @apply fill-wave-500;
 }
 
 .ui.button.ghost:hover,


### PR DESCRIPTION
Como nossos custom icons não são fontes, as classes css `text-` não funcionam pra trocar a cor deles, como estávamos usando no botão.

Precisamos de regras extras no botão pra usar a cor correta quando o ícone é SVG.

Exemplo:

**Antes**
<img width="56" alt="Screen Shot 2019-08-15 at 10 01 44 AM" src="https://user-images.githubusercontent.com/5216049/63096522-8154a400-bf44-11e9-8741-49b2bb270451.png">

**Depois**
<img width="52" alt="Screen Shot 2019-08-15 at 10 01 34 AM" src="https://user-images.githubusercontent.com/5216049/63096520-8154a400-bf44-11e9-909d-f435a724b1ba.png">
