### PR TITLE
fix(menu): Fix color of custom icons inside menu items

### DIFF
--- a/packages/orion/src/Menu/menu.css
+++ b/packages/orion/src/Menu/menu.css
@@ -16,10 +16,6 @@
   @apply ml-0;
 }
 
-.ui.menu .item > .icon {
-  @apply mr-4;
-}
-
 .ui.menu .item.active {
   @apply font-medium text-space-900;
 }
@@ -30,4 +26,22 @@
 
 .ui.menu .menu.right {
   @apply flex ml-auto;
+}
+
+/** Menu item with icon **/
+
+.ui.menu .item > .icon {
+  @apply mr-4;
+}
+
+.ui.menu .item > svg.icon {
+  @apply fill-gray-800;
+}
+
+.ui.menu .item:hover > svg.icon {
+  @apply fill-gray-900;
+}
+
+.ui.menu .item.active > svg.icon {
+  @apply fill-space-900;
 }

--- a/packages/orion/src/Menu/switcher.css
+++ b/packages/orion/src/Menu/switcher.css
@@ -29,3 +29,11 @@
 .ui.menu.switcher .item.active > .icon {
   @apply text-space-600;
 }
+
+.ui.menu.switcher .item > svg.icon {
+  @apply fill-gray-700;
+}
+
+.ui.menu.switcher .item.active > svg.icon {
+  @apply fill-space-600;
+}


### PR DESCRIPTION
Como nossos custom icons não são fontes, as classes css text- não funcionam pra trocar a cor deles, como estávamos usando no menu.

Precisamos de regras extras no botão pra usar a cor correta quando o ícone é SVG.

Exemplo (eu sei que é quase imperceptível, mas não para um designer 😆):

**Antes**
<img width="89" alt="Screen Shot 2019-08-15 at 10 20 18 AM" src="https://user-images.githubusercontent.com/5216049/63097497-f5904700-bf46-11e9-8854-51c63e76edaa.png">

**Depois**
<img width="92" alt="Screen Shot 2019-08-15 at 10 20 13 AM" src="https://user-images.githubusercontent.com/5216049/63097496-f5904700-bf46-11e9-9051-13fe6a3e8f6c.png">

