### PR TITLE
feature(menu): Fix icon color and focus/active states

### DIFF
--- a/packages/orion/src/Menu/menu.css
+++ b/packages/orion/src/Menu/menu.css
@@ -5,10 +5,15 @@
 }
 
 .ui.menu .item {
-  @apply cursor-pointer flex items-center ml-40 text-base text-gray-800;
+  @apply cursor-pointer flex items-center ml-40 outline-none text-base text-gray-800;
 }
 
-.ui.menu .item:hover {
+.ui.menu .item:hover,
+.ui.menu .item:focus {
+  @apply text-gray-700;
+}
+
+.ui.menu .item:active {
   @apply text-gray-900;
 }
 
@@ -31,17 +36,26 @@
 /** Menu item with icon **/
 
 .ui.menu .item > .icon {
-  @apply mr-4;
+  @apply mr-4 text-gray-700;
 }
 
 .ui.menu .item > svg.icon {
-  @apply fill-gray-800;
+  @apply fill-gray-700;
 }
 
-.ui.menu .item:hover > svg.icon {
+.ui.menu .item:hover > svg.icon,
+.ui.menu .item:focus > svg.icon {
+  @apply fill-gray-700;
+}
+
+.ui.menu .item:active > svg.icon {
   @apply fill-gray-900;
 }
 
+.ui.menu .item.active > .icon {
+  @apply text-space-600;
+}
+
 .ui.menu .item.active > svg.icon {
-  @apply fill-space-900;
+  @apply fill-space-600;
 }

--- a/packages/orion/src/Menu/switcher.css
+++ b/packages/orion/src/Menu/switcher.css
@@ -7,33 +7,15 @@
   @apply ml-0;
 }
 
-.ui.menu.switcher .item:not(.active):hover {
+.ui.menu.switcher .item:not(.active):hover,
+.ui.menu.switcher .item:not(.active):focus {
   @apply bg-gray-900-8;
 }
 
-.ui.menu.switcher .item:not(.active):active,
-.ui.menu.switcher .item:not(.active):focus {
+.ui.menu.switcher .item:not(.active):active {
   @apply bg-gray-900-16;
 }
 
 .ui.menu.switcher .item.active {
-  @apply bg-space-100 font-normal text-space-900;
-}
-
-/** Icon **/
-
-.ui.menu.switcher .item > .icon {
-  @apply text-gray-700;
-}
-
-.ui.menu.switcher .item.active > .icon {
-  @apply text-space-600;
-}
-
-.ui.menu.switcher .item > svg.icon {
-  @apply fill-gray-700;
-}
-
-.ui.menu.switcher .item.active > svg.icon {
-  @apply fill-space-600;
+  @apply bg-space-100 font-normal;
 }


### PR DESCRIPTION
Os menu items não tinham hover/active states ainda e estavam com a cor errada nos ícones.

**Antes (cor do ícone)**
<img width="239" alt="Screen Shot 2019-08-15 at 12 47 57 PM" src="https://user-images.githubusercontent.com/5216049/63107375-36925680-bf5b-11e9-853c-9e1103eeac58.png">

**Depois (cor do ícone)**
<img width="241" alt="Screen Shot 2019-08-15 at 12 47 42 PM" src="https://user-images.githubusercontent.com/5216049/63107374-36925680-bf5b-11e9-9f75-993ffe714346.png">
