### PR TITLE
fix(color): Fix the color used in box-shadow

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -167,12 +167,12 @@ module.exports = {
       '0': '0'
     },
     boxShadow: {
-      100: '0 0 0 1px rgba(62, 73, 101, 0.15)',
+      100: '0 0 0 1px rgba(61, 62, 63, .16)',
       200: '0 4px 6px 0px rgba(61, 62, 63, .16)',
       300: '0 8px 10px 0px rgba(61, 62, 63, .16)',
       400: '0 16px 24px 0px rgba(61, 62, 63, .16)',
       500: '0 24px 32px 0px rgba(61, 62, 63, .16)',
-      default: '0 4px 16px -1px rgba(62, 73, 101, .16)',
+      default: '0 4px 16px -1px rgba(61, 62, 63, .16)',
       'field-hover': 'inset 0 0px 0px 1px rgba(61, 62, 63, .16)',
       'field-active': '0 0px 0px 1px rgba(61, 62, 63, .48)',
       'error-field-hover': '0 0px 0px 1px rgba(201, 44, 70, .32)',

--- a/packages/orion/src/Card/card.css
+++ b/packages/orion/src/Card/card.css
@@ -1,5 +1,5 @@
 .ui.card {
-  @apply bg-white inline-block rounded shadow-100;
+  @apply bg-white border-1 border-gray-900-16 inline-block rounded;
 }
 
 .ui.card.fluid {


### PR DESCRIPTION
Notei que estávamos usando `62, 73, 101` em dois box-shadows da gente, que era o antigo `n600`. Essa cor não existe mais na nossa paleta, então confirmei com Bruno que ela estava errada, deveria ser `61, 62, 63` (nosso `gray-900`), como nos nossos outros box-shadows.

Corrigi isso e aproveitei pra trocar o `shadow-100` dos nossos cards por uma borda normal, agora que a cor está em nossa paleta. A borda dá o mesmo efeito e é mais versátil (não causa problemas de overflow como box-shadow causa, e permite colocar outro box-shadow por cima mais facilmente).