### PR TITLE
Chore: Using Semantic UI React Fork

### DIFF
--- a/packages/orion/package.json
+++ b/packages/orion/package.json
@@ -28,17 +28,15 @@
   "license": "ISC",
   "homepage": "https://inloco.github.io/orion",
   "dependencies": {
+    "@inloco/semantic-ui-react": "^0.87.3-beta.1",
     "classnames": "^2.2.6",
     "keyboard-key": "^1.0.4",
     "lodash": "^4.17.14",
     "moment": "^2.24.0",
     "prop-types": "^15.6.2",
-    "react": "^16.9.0",
     "react-dates": "^20.2.5",
-    "react-dom": "^16.9.0",
     "react-lottie": "^1.2.3",
-    "react-toastify": "^5.3.1",
-    "semantic-ui-react": "^0.87.2"
+    "react-toastify": "^5.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -70,6 +68,10 @@
     "merge-stream": "^2.0.0",
     "postcss-import": "^12.0.1",
     "tailwindcss": "^1.0.4"
+  },
+  "peerDependencies": {
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
   },
   "jest-junit": {
     "outputDirectory": "./reports/junit",

--- a/packages/orion/package.json
+++ b/packages/orion/package.json
@@ -28,7 +28,7 @@
   "license": "ISC",
   "homepage": "https://inloco.github.io/orion",
   "dependencies": {
-    "@inloco/semantic-ui-react": "^0.87.3-beta.1",
+    "@inloco/semantic-ui-react": "^0.87.3",
     "classnames": "^2.2.6",
     "keyboard-key": "^1.0.4",
     "lodash": "^4.17.14",

--- a/packages/orion/src/Button/button.css
+++ b/packages/orion/src/Button/button.css
@@ -1,176 +1,176 @@
-.ui.button {
+.orion.button {
   @apply h-40 rounded-full text-base font-default font-medium outline-none inline-flex items-center transition-default;
   transition-property: background-color, opacity;
 }
 
-.ui.button.fluid {
+.orion.button.fluid {
   @apply w-full justify-center;
 }
 
-.ui.button > .icon {
+.orion.button > .icon {
   @apply flex items-center;
 }
 
-.ui.button:not(.icon) > .icon {
+.orion.button:not(.icon) > .icon {
   @apply flex justify-center;
   @apply h-24 w-24;
   vertical-align: sub;
 }
 
-.ui.button:not(.icon):not(.subtle) {
+.orion.button:not(.icon):not(.subtle) {
   @apply px-24 justify-center;
   min-width: 96px;
 }
 
 /* Icon only */
 
-.ui.button.icon {
+.orion.button.icon {
   @apply justify-center p-0 w-40;
 }
 
-.ui.button.icon:hover,
-.ui.button.icon:focus {
+.orion.button.icon:hover,
+.orion.button.icon:focus {
   @apply bg-gray-900-8;
 }
 
-.ui.button.icon:active {
+.orion.button.icon:active {
   @apply bg-gray-900-12;
 }
 
 /* Disabled */
 
-.ui.button.disabled {
+.orion.button.disabled {
   @apply opacity-40 pointer-events-none;
 }
 
 /* Primary */
 
-.ui.button.primary {
+.orion.button.primary {
   @apply bg-wave-500 text-white;
 }
 
-.ui.button.primary svg.icon {
+.orion.button.primary svg.icon {
   @apply fill-white;
 }
 
-.ui.button.primary:hover,
-.ui.button.primary:focus {
+.orion.button.primary:hover,
+.orion.button.primary:focus {
   @apply bg-wave-600;
 }
 
-.ui.button.primary:active {
+.orion.button.primary:active {
   @apply bg-wave-700;
 }
 
 /* Secondary */
 
-.ui.button.secondary {
+.orion.button.secondary {
   @apply bg-gray-900-8 text-gray-900;
 }
 
-.ui.button.secondary:hover,
-.ui.button.secondary:focus {
+.orion.button.secondary:hover,
+.orion.button.secondary:focus {
   @apply bg-gray-900-12;
 }
 
-.ui.button.secondary:active {
+.orion.button.secondary:active {
   @apply bg-gray-900-16;
 }
 
 /* Subtle */
 
-.ui.button.subtle {
+.orion.button.subtle {
   @apply bg-transparent;
 }
 
 /* Subtle Primary */
 
-.ui.button.subtle.primary {
+.orion.button.subtle.primary {
   @apply text-wave-500;
 }
 
-.ui.button.subtle.primary svg.icon {
+.orion.button.subtle.primary svg.icon {
   @apply fill-wave-500;
 }
 
-.ui.button.subtle.primary:hover,
-.ui.button.subtle.primary:focus {
+.orion.button.subtle.primary:hover,
+.orion.button.subtle.primary:focus {
   @apply bg-transparent text-wave-600;
 }
 
-.ui.button.subtle.primary:hover svg.icon,
-.ui.button.subtle.primary:focus svg.icon {
+.orion.button.subtle.primary:hover svg.icon,
+.orion.button.subtle.primary:focus svg.icon {
   @apply fill-wave-600;
 }
 
-.ui.button.subtle.primary:active {
+.orion.button.subtle.primary:active {
   @apply bg-transparent text-wave-700;
 }
 
-.ui.button.subtle.primary:active svg.icon {
+.orion.button.subtle.primary:active svg.icon {
   @apply fill-wave-700;
 }
 
 /* Subtle Secondary */
 
-.ui.button.subtle.secondary {
+.orion.button.subtle.secondary {
   @apply text-gray-700;
 }
 
-.ui.button.subtle.secondary svg.icon {
+.orion.button.subtle.secondary svg.icon {
   @apply fill-gray-700;
 }
 
-.ui.button.subtle.secondary:hover,
-.ui.button.subtle.secondary:focus {
+.orion.button.subtle.secondary:hover,
+.orion.button.subtle.secondary:focus {
   @apply bg-transparent text-gray-800;
 }
 
-.ui.button.subtle.secondary:hover svg.icon,
-.ui.button.subtle.secondary:focus svg.icon {
+.orion.button.subtle.secondary:hover svg.icon,
+.orion.button.subtle.secondary:focus svg.icon {
   @apply fill-gray-800;
 }
 
-.ui.button.subtle.secondary:active {
+.orion.button.subtle.secondary:active {
   @apply bg-transparent text-gray-900;
 }
 
-.ui.button.subtle.secondary:active svg.icon {
+.orion.button.subtle.secondary:active svg.icon {
   @apply fill-gray-900;
 }
 
 /* Subtle Icon */
-.ui.button.subtle:not(.icon) {
+.orion.button.subtle:not(.icon) {
   @apply h-auto;
 }
 
-.ui.button.subtle.primary.icon:hover,
-.ui.button.subtle.secondary.icon:hover,
-.ui.button.subtle.primary.icon:focus,
-.ui.button.subtle.secondary.icon:focus {
+.orion.button.subtle.primary.icon:hover,
+.orion.button.subtle.secondary.icon:hover,
+.orion.button.subtle.primary.icon:focus,
+.orion.button.subtle.secondary.icon:focus {
   @apply bg-gray-900-8;
 }
 
-.ui.button.subtle.primary.icon:active,
-.ui.button.subtle.secondary.icon:active {
+.orion.button.subtle.primary.icon:active,
+.orion.button.subtle.secondary.icon:active {
   @apply bg-gray-900-12;
 }
 
 /* Ghost */
 
-.ui.button.ghost {
+.orion.button.ghost {
   @apply bg-white text-wave-500 border border-wave-500;
 }
 
-.ui.button.ghost svg.icon {
+.orion.button.ghost svg.icon {
   @apply fill-wave-500;
 }
 
-.ui.button.ghost:hover,
-.ui.button.ghost:focus {
+.orion.button.ghost:hover,
+.orion.button.ghost:focus {
   @apply bg-wave-500-8;
 }
 
-.ui.button.ghost:active {
+.orion.button.ghost:active {
   @apply bg-wave-500-16;
 }

--- a/packages/orion/src/Button/index.js
+++ b/packages/orion/src/Button/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Button as SemanticButton } from 'semantic-ui-react'
+import { Button as SemanticButton } from '@inloco/semantic-ui-react'
 
 import { createShorthandFactory } from '../utils/factories'
 

--- a/packages/orion/src/Card/card.css
+++ b/packages/orion/src/Card/card.css
@@ -1,20 +1,20 @@
-.ui.card {
+.orion.card {
   @apply bg-white border-1 border-gray-900-16 inline-block rounded;
 }
 
-.ui.card.fluid {
+.orion.card.fluid {
   @apply w-full;
 }
 
-.ui.card .header {
+.orion.card .header {
   @apply font-display mb-24 tracking-h2 text-lg text-gray-800;
 }
 
-.ui.card > .content {
+.orion.card > .content {
   @apply p-24;
 }
 
-.ui.card > .extra {
+.orion.card > .extra {
   @apply flex items-center justify-end px-24 py-8;
   @apply border-t-1 border-gray-900-16;
 }

--- a/packages/orion/src/Checkbox/checkbox.css
+++ b/packages/orion/src/Checkbox/checkbox.css
@@ -1,70 +1,74 @@
-.ui.checkbox {
+.orion.checkbox {
   @apply my-2 relative;
 }
 
-.ui.checkbox input[type='checkbox'] {
+.orion.checkbox input[type='checkbox'] {
   @apply absolute top-0 left-0 h-16 w-16;
   @apply opacity-0;
   @apply block !important;
 }
 
-.ui.checkbox input[type='checkbox'] ~ label {
+.orion.checkbox input[type='checkbox'] ~ label {
   @apply block cursor-pointer text-base text-gray-900 pl-24;
   line-height: 16px;
 }
 
-.ui.checkbox input[type='checkbox'] ~ label:before {
+.orion.checkbox input[type='checkbox'] ~ label:before {
   @apply absolute top-0 left-0 h-16 w-16;
   @apply border border-gray-900-24 rounded;
   content: '';
 }
 
-.ui.checkbox input[type='checkbox'] ~ label:hover:before {
+.orion.checkbox input[type='checkbox'] ~ label:hover:before {
   @apply bg-gray-900-8;
 }
 
-.ui.checkbox input[type='checkbox'] ~ label:active:before,
-.ui.checkbox input[type='checkbox']:focus ~ label:before {
+.orion.checkbox input[type='checkbox'] ~ label:active:before,
+.orion.checkbox input[type='checkbox']:focus ~ label:before {
   @apply bg-gray-900-16;
 }
 
-.ui.checkbox input[type='checkbox']:checked ~ label:before,
-.ui.checkbox input[type='checkbox']:indeterminate ~ label:before {
+.orion.checkbox input[type='checkbox']:checked ~ label:before,
+.orion.checkbox input[type='checkbox']:indeterminate ~ label:before {
   @apply bg-wave-500;
 }
 
-.ui.checkbox:not(.disabled) input[type='checkbox']:checked ~ label:hover:before,
-.ui.checkbox:not(.disabled)
+.orion.checkbox:not(.disabled)
+  input[type='checkbox']:checked
+  ~ label:hover:before,
+.orion.checkbox:not(.disabled)
   input[type='checkbox']:indeterminate
   ~ label:hover:before {
   @apply bg-wave-600;
 }
 
-.ui.checkbox:not(.disabled)
+.orion.checkbox:not(.disabled)
   input[type='checkbox']:checked
   ~ label:active:before,
-.ui.checkbox:not(.disabled)
+.orion.checkbox:not(.disabled)
   input[type='checkbox']:indeterminate
   ~ label:active:before,
-.ui.checkbox:not(.disabled) input[type='checkbox']:checked:focus ~ label:before,
-.ui.checkbox:not(.disabled)
+.orion.checkbox:not(.disabled)
+  input[type='checkbox']:checked:focus
+  ~ label:before,
+.orion.checkbox:not(.disabled)
   input[type='checkbox']:indeterminate:focus
   ~ label:before {
   @apply bg-wave-700;
 }
 
-.ui.checkbox input[type='checkbox']:checked ~ label:after,
-.ui.checkbox input[type='checkbox']:indeterminate ~ label:after {
+.orion.checkbox input[type='checkbox']:checked ~ label:after,
+.orion.checkbox input[type='checkbox']:indeterminate ~ label:after {
   @apply absolute top-0 left-0 h-16 w-16;
   @apply flex items-center justify-center text-white;
   font-family: 'Material Icons';
 }
 
-.ui.checkbox input[type='checkbox']:checked ~ label:after {
+.orion.checkbox input[type='checkbox']:checked ~ label:after {
   content: '\E876';
 }
 
-.ui.checkbox input[type='checkbox']:indeterminate ~ label:after {
+.orion.checkbox input[type='checkbox']:indeterminate ~ label:after {
   content: '\E15B';
 }
 
@@ -72,15 +76,15 @@
  * Disabled
  */
 
-.ui.checkbox.disabled input[type='checkbox'] ~ label {
+.orion.checkbox.disabled input[type='checkbox'] ~ label {
   @apply text-gray-800;
 }
 
-.ui.checkbox.disabled input[type='checkbox'] ~ label:before {
+.orion.checkbox.disabled input[type='checkbox'] ~ label:before {
   @apply bg-gray-900-8;
 }
 
-.ui.checkbox.disabled input[type='checkbox'] ~ label:after {
+.orion.checkbox.disabled input[type='checkbox'] ~ label:after {
   @apply text-gray-800;
 }
 
@@ -88,7 +92,7 @@
  * Space between checkboxes
  */
 
-.ui.checkbox + .ui.checkbox {
+.orion.checkbox + .orion.checkbox {
   /* 16px space + 2px margin from the top checkbox + 2px margin from the bottom checkbox */
   margin-top: 20px;
 }

--- a/packages/orion/src/Datepicker/datepicker.css
+++ b/packages/orion/src/Datepicker/datepicker.css
@@ -1,4 +1,4 @@
-.ui.datepicker {
+.orion.datepicker {
   @apply -mx-24;
 }
 

--- a/packages/orion/src/Datepicker/index.js
+++ b/packages/orion/src/Datepicker/index.js
@@ -19,7 +19,7 @@ const Datepicker = ({
 
   const date = dateProp || dateState
   return (
-    <div className="ui datepicker">
+    <div className="orion datepicker">
       <ReactDatesDatepicker
         as={DayPickerSingleDateController}
         date={toMoment(date)}

--- a/packages/orion/src/Dimmer/dimmer.css
+++ b/packages/orion/src/Dimmer/dimmer.css
@@ -1,10 +1,10 @@
-.ui.dimmer {
+.orion.dimmer {
   @apply bg-gray-50 flex z-30;
   @apply absolute top-0 left-0 w-full h-full;
   @apply transition-default opacity-0 pointer-events-none;
   transition-property: opacity;
 }
 
-.ui.dimmer.active {
+.orion.dimmer.active {
   @apply opacity-80 pointer-events-auto;
 }

--- a/packages/orion/src/Dropdown/Dropdown.test.js
+++ b/packages/orion/src/Dropdown/Dropdown.test.js
@@ -42,7 +42,7 @@ describe('when an option is selected', () => {
 
     const [label] = getAllByText('Red')
     expect(label).toBeTruthy()
-    expect(label).toHaveClass('ui label')
+    expect(label).toHaveClass('orion label')
   })
 
   it('should show option on the list, as selected', () => {
@@ -61,7 +61,7 @@ describe('when an option is selected', () => {
 
     it('should stop rendering a label with the option', () => {
       const { getByText } = renderResult
-      expect(getByText('Red')).not.toHaveClass('ui label')
+      expect(getByText('Red')).not.toHaveClass('orion label')
     })
 
     it('should show option on the list, as unselected', () => {

--- a/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
+++ b/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
@@ -1,24 +1,24 @@
-.ui.dropdown .menu > .item .text {
+.orion.dropdown .menu > .item .text {
   @apply leading-20 truncate;
 }
 
-.ui.dropdown .menu > .item,
-.ui.dropdown .menu > .message {
+.orion.dropdown .menu > .item,
+.orion.dropdown .menu > .message {
   @apply px-16 py-8;
 }
 
-.ui.dropdown .menu > .item.active {
+.orion.dropdown .menu > .item.active {
   @apply font-medium;
 }
 
-.ui.dropdown .menu > .item:hover {
+.orion.dropdown .menu > .item:hover {
   @apply bg-gray-900-8;
 }
 
-.ui.dropdown .menu > .item.selected {
+.orion.dropdown .menu > .item.selected {
   @apply bg-gray-100;
 }
 
-.ui.dropdown .menu > .item .description {
+.orion.dropdown .menu > .item .description {
   @apply mt-4 leading-14 text-gray-800 text-sm truncate;
 }

--- a/packages/orion/src/Dropdown/DropdownItem/index.js
+++ b/packages/orion/src/Dropdown/DropdownItem/index.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import React from 'react'
-import { Dropdown as SemanticDropdown } from 'semantic-ui-react'
+import { Dropdown as SemanticDropdown } from '@inloco/semantic-ui-react'
 
 import { createShorthandFactory } from '../../utils/factories'
 

--- a/packages/orion/src/Dropdown/DropdownKeepSelected/index.js
+++ b/packages/orion/src/Dropdown/DropdownKeepSelected/index.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import React, { useState } from 'react'
-import { Dropdown as SemanticDropdown } from 'semantic-ui-react'
+import { Dropdown as SemanticDropdown } from '@inloco/semantic-ui-react'
 
 const DOUBLE_PREFIX = 'double:'
 

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -1,57 +1,57 @@
 @import './DropdownItem/dropdown-item.css';
 
-.ui.dropdown {
+.orion.dropdown {
   @apply flex-wrap inline-flex items-center relative;
   @apply cursor-pointer min-h-48 px-16 outline-none select-none;
   min-width: 256px;
 }
 
-.ui.dropdown.compact {
+.orion.dropdown.compact {
   @apply min-w-0;
 }
 
-.ui.dropdown.compact > .menu {
+.orion.dropdown.compact > .menu {
   min-width: max-content;
 }
 
-.ui.dropdown.fluid {
+.orion.dropdown.fluid {
   @apply w-full;
 }
 
-.ui.dropdown.small {
+.orion.dropdown.small {
   @apply min-h-24;
 }
 
-.ui.dropdown .text {
+.orion.dropdown .text {
   @apply text-gray-900 z-10;
 }
 
-.ui.dropdown .text.default {
+.orion.dropdown .text.default {
   @apply text-gray-800;
 }
 
-.ui.dropdown .text.default.filtered {
+.orion.dropdown .text.default.filtered {
   @apply invisible;
 }
 
-.ui.dropdown > .menu {
+.orion.dropdown > .menu {
   @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full;
   top: 100%;
 }
 
-.ui.dropdown.active > .menu {
+.orion.dropdown.active > .menu {
   @apply block rounded;
 }
 
-.ui.dropdown.disabled {
+.orion.dropdown.disabled {
   @apply pointer-events-none cursor-default;
 }
 
-.ui.dropdown > .icon {
+.orion.dropdown > .icon {
   @apply ml-auto -mr-8;
 }
 
-.ui.dropdown.active .dropdown-icon {
+.orion.dropdown.active .dropdown-icon {
   transform: rotate(-180deg);
 }
 
@@ -63,15 +63,15 @@
  * Search
  */
 
-.ui.dropdown.search {
+.orion.dropdown.search {
   @apply inline-flex cursor-text;
 }
 
-.ui.dropdown.search input {
+.orion.dropdown.search input {
   @apply absolute bg-transparent outline-none;
 }
 
-.ui.dropdown.search.active input:focus + .text {
+.orion.dropdown.search.active input:focus + .text {
   @apply text-gray-800;
 }
 
@@ -79,15 +79,15 @@
  * Multiple
  */
 
-.ui.dropdown.multiple .ui.label {
+.orion.dropdown.multiple .orion.label {
   @apply -ml-8 mr-16;
 }
 
-.ui.dropdown.multiple .ui.label + input {
+.orion.dropdown.multiple .orion.label + input {
   @apply -ml-8;
 }
 
-.ui.dropdown.multiple.small > .ui.label {
+.orion.dropdown.multiple.small > .orion.label {
   @apply h-24 !important;
 }
 
@@ -95,22 +95,22 @@
  * Multiple + Keep selected
  */
 
-.ui.dropdown.multiple.keep-selected > .menu > .item.active {
+.orion.dropdown.multiple.keep-selected > .menu > .item.active {
   @apply font-normal .relative;
 }
 
-.ui.dropdown.multiple.keep-selected > .menu > .item::after {
+.orion.dropdown.multiple.keep-selected > .menu > .item::after {
   @apply absolute text-lg text-wave-500;
   top: calc(50% - 10px);
   right: 16px;
 }
 
-.ui.dropdown.multiple.keep-selected > .menu > .item.active::after {
+.orion.dropdown.multiple.keep-selected > .menu > .item.active::after {
   content: 'check';
   font-family: 'Material Icons';
 }
 
-.ui.dropdown.multiple.keep-selected.disabled > .menu {
+.orion.dropdown.multiple.keep-selected.disabled > .menu {
   @apply hidden;
 }
 
@@ -118,27 +118,27 @@
  * Search + Multiple
  */
 
-.ui.dropdown.search.multiple {
+.orion.dropdown.search.multiple {
   @apply h-auto py-4;
 }
 
-.ui.dropdown.search.multiple > .ui.label {
+.orion.dropdown.search.multiple > .orion.label {
   @apply my-2;
 }
 
-.ui.dropdown.search.multiple > input {
+.orion.dropdown.search.multiple > input {
   @apply h-32 my-2 static w-32 max-w-full;
 }
 
-.ui.dropdown.search.multiple.small > input {
+.orion.dropdown.search.multiple.small > input {
   @apply h-24;
 }
 
-.ui.dropdown.search.multiple > .sizer {
+.orion.dropdown.search.multiple > .sizer {
   @apply hidden p-2;
 }
 
-.ui.dropdown.search.multiple > .text {
+.orion.dropdown.search.multiple > .text {
   @apply absolute;
 }
 
@@ -146,38 +146,38 @@
  * Selection
  */
 
-.ui.dropdown.selection {
+.orion.dropdown.selection {
   @apply bg-white border border-gray-900-24 rounded;
 }
 
-.ui.dropdown.selection.small {
+.orion.dropdown.selection.small {
   @apply min-h-32;
 }
 
-.ui.dropdown.selection.disabled {
+.orion.dropdown.selection.disabled {
   @apply bg-gray-900-8;
 }
 
-.ui.dropdown.selection:hover {
+.orion.dropdown.selection:hover {
   @apply shadow-field-hover;
 }
 
-.ui.dropdown.selection:active,
-.ui.dropdown.selection:focus {
+.orion.dropdown.selection:active,
+.orion.dropdown.selection:focus {
   @apply shadow-field-active;
 }
 
-.ui.dropdown.selection > .menu {
+.orion.dropdown.selection > .menu {
   @apply cursor-pointer;
 }
 
 /** Inline Menu **/
 
-.ui.dropdown.inline-menu > .menu {
+.orion.dropdown.inline-menu > .menu {
   @apply block border-0 shadow-none;
 }
 
-.ui.dropdown.inline-menu > .dropdown-icon {
+.orion.dropdown.inline-menu > .dropdown-icon {
   @apply hidden;
 }
 
@@ -185,43 +185,43 @@
  * Validation
  */
 
-.ui.dropdown.error {
+.orion.dropdown.error {
   @apply border-magenta-500;
 }
 
-.ui.dropdown.error.selection:hover {
+.orion.dropdown.error.selection:hover {
   @apply shadow-error-field-hover;
 }
 
-.ui.dropdown.error.selection:active,
-.ui.dropdown.error.selection:focus {
+.orion.dropdown.error.selection:active,
+.orion.dropdown.error.selection:focus {
   @apply shadow-error-field-active;
 }
 
-.ui.dropdown.warning {
+.orion.dropdown.warning {
   @apply border-yellow-500;
 }
 
-.ui.dropdown.warning.selection:hover {
+.orion.dropdown.warning.selection:hover {
   @apply shadow-warning-field-hover;
 }
 
-.ui.dropdown.warning.selection:active,
-.ui.dropdown.warning.selection:focus {
+.orion.dropdown.warning.selection:active,
+.orion.dropdown.warning.selection:focus {
   @apply shadow-warning-field-active;
 }
 
 /** Loading **/
 
-.ui.loading.dropdown > .dropdown-loading-icon {
+.orion.loading.dropdown > .dropdown-loading-icon {
   @apply relative;
 
   height: 20px;
   width: 20px;
 }
 
-.ui.loading.dropdown > .dropdown-loading-icon:before,
-.ui.loading.dropdown > .dropdown-loading-icon:after {
+.orion.loading.dropdown > .dropdown-loading-icon:before,
+.orion.loading.dropdown > .dropdown-loading-icon:after {
   @apply absolute;
   @apply border-2 rounded-full;
   @apply w-full h-full;
@@ -229,11 +229,11 @@
   content: '';
 }
 
-.ui.loading.dropdown > .dropdown-loading-icon:before {
+.orion.loading.dropdown > .dropdown-loading-icon:before {
   @apply border-gray-900-16;
 }
 
-.ui.loading.dropdown > .dropdown-loading-icon:after {
+.orion.loading.dropdown > .dropdown-loading-icon:after {
   animation: dropdown-spin 0.6s linear;
   animation-iteration-count: infinite;
 

--- a/packages/orion/src/Dropdown/index.js
+++ b/packages/orion/src/Dropdown/index.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Dropdown as SemanticDropdown } from 'semantic-ui-react'
+import { Dropdown as SemanticDropdown } from '@inloco/semantic-ui-react'
 
 import { Sizes, sizePropType } from '../utils/sizes'
 import DropdownItem from './DropdownItem'

--- a/packages/orion/src/Filter/filter.css
+++ b/packages/orion/src/Filter/filter.css
@@ -1,4 +1,4 @@
-.ui.button.filter-trigger {
+.orion.button.filter-trigger {
   @apply bg-white border border-gray-900-24 cursor-pointer font-normal rounded transition-default;
   @apply inline-flex h-32 items-center text-gray-800;
   @apply outline-none;
@@ -6,13 +6,13 @@
   transition-property: background-color, color;
 }
 
-.ui.button.filter-trigger:hover,
-.ui.button.filter-trigger:focus {
+.orion.button.filter-trigger:hover,
+.orion.button.filter-trigger:focus {
   @apply bg-gray-900-8;
 }
 
-.ui.button.filter-trigger.active,
-.ui.button.filter-trigger.selected {
+.orion.button.filter-trigger.active,
+.orion.button.filter-trigger.selected {
   @apply bg-space-100 border-none text-space-900;
 
   /*
@@ -24,20 +24,20 @@
   padding-right: 17px !important;
 }
 
-.ui.button.filter-trigger.active:hover,
-.ui.button.filter-trigger.selected:hover,
-.ui.button.filter-trigger.selected:focus {
+.orion.button.filter-trigger.active:hover,
+.orion.button.filter-trigger.selected:hover,
+.orion.button.filter-trigger.selected:focus {
   @apply bg-space-200;
 }
 
-.ui.popup.filter .filter-content {
+.orion.popup.filter .filter-content {
   @apply p-8 pb-24;
 }
 
-.ui.popup.filter .filter-buttons {
+.orion.popup.filter .filter-buttons {
   @apply flex justify-between;
 }
 
-.ui.popup.filter .filter-footer-content {
+.orion.popup.filter .filter-footer-content {
   @apply leading-14 font-display mr-8 text-sm text-gray-800;
 }

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -84,7 +84,7 @@ const Filter = ({
 
   return (
     <Popup
-      className={cx(className, 'ui filter')}
+      className={cx(className, 'orion filter')}
       basic
       trigger={trigger}
       open={open}

--- a/packages/orion/src/Form/Dropdown/index.js
+++ b/packages/orion/src/Form/Dropdown/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Form } from 'semantic-ui-react'
+import { Form } from '@inloco/semantic-ui-react'
 
 import Field from '../Field'
 import Dropdown from '../../Dropdown'

--- a/packages/orion/src/Form/Field/field.css
+++ b/packages/orion/src/Form/Field/field.css
@@ -1,45 +1,45 @@
-.ui.form .field {
+.orion.form .field {
   @apply relative;
 }
 
 /* Floated label */
-.ui.form .field.floatingLabel label {
+.orion.form .field.floatingLabel label {
   @apply absolute border-l-1 top-0 block .cursor-text ml-16 text-gray-800 text-base transition-default z-10;
   transition-property: margin-top, font-size;
   border-color: transparent !important;
   margin-top: 17px;
 }
 
-.ui.form .field.floatingLabel.filled label,
-.ui.form .field.floatingLabel:focus-within label {
+.orion.form .field.floatingLabel.filled label,
+.orion.form .field.floatingLabel:focus-within label {
   @apply mt-8 text-sm;
 }
 
-.ui.form .field.floatingLabel .dropdown .text,
-.ui.form .field.floatingLabel input {
+.orion.form .field.floatingLabel .dropdown .text,
+.orion.form .field.floatingLabel input {
   @apply pt-16;
 }
 
-.ui.form .field.floatingLabel .dropdown .default.text,
-.ui.form .field.floatingLabel input::placeholder {
+.orion.form .field.floatingLabel .dropdown .default.text,
+.orion.form .field.floatingLabel input::placeholder {
   @apply transition-default;
   transition-property: color;
   color: transparent;
 }
 
-.ui.form .field.floatingLabel:focus-within .dropdown .default.text,
-.ui.form .field.floatingLabel:focus-within input::placeholder {
+.orion.form .field.floatingLabel:focus-within .dropdown .default.text,
+.orion.form .field.floatingLabel:focus-within input::placeholder {
   @apply text-gray-800;
 }
 
 /* Outside label */
-.ui.form .field label {
+.orion.form .field label {
   @apply block mb-4;
 }
 
 /* Error */
-.ui.form .field.error input,
-.ui.form .field.error .dropdown {
+.orion.form .field.error input,
+.orion.form .field.error .dropdown {
   @apply border-magenta-500;
 }
 

--- a/packages/orion/src/Form/Field/index.js
+++ b/packages/orion/src/Form/Field/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Form } from 'semantic-ui-react'
+import { Form } from '@inloco/semantic-ui-react'
 
 import Input from '../../Input'
 import Dropdown from '../../Dropdown'

--- a/packages/orion/src/Form/Input/index.js
+++ b/packages/orion/src/Form/Input/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Form } from 'semantic-ui-react'
+import { Form } from '@inloco/semantic-ui-react'
 
 import Field from '../Field'
 import Input from '../../Input'

--- a/packages/orion/src/Form/index.js
+++ b/packages/orion/src/Form/index.js
@@ -1,4 +1,4 @@
-import { Form } from 'semantic-ui-react'
+import { Form } from '@inloco/semantic-ui-react'
 
 import './Field'
 import './Input'

--- a/packages/orion/src/Icon/index.js
+++ b/packages/orion/src/Icon/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Icon as SemanticIcon } from 'semantic-ui-react'
+import { Icon as SemanticIcon } from '@inloco/semantic-ui-react'
 
 import { CUSTOM_ICONS_MAP } from './custom'
 import { createShorthandFactory } from '../utils/factories'

--- a/packages/orion/src/InfoIcon/index.js
+++ b/packages/orion/src/InfoIcon/index.js
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Popup } from 'semantic-ui-react'
+import { Popup } from '@inloco/semantic-ui-react'
 
 import Icon from '../Icon'
 import { Sizes } from '../utils/sizes'

--- a/packages/orion/src/Input/index.js
+++ b/packages/orion/src/Input/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Input as SemanticInput } from 'semantic-ui-react'
+import { Input as SemanticInput } from '@inloco/semantic-ui-react'
 
 import { createShorthandFactory } from '../utils/factories'
 import { Sizes, sizePropType } from '../utils/sizes'

--- a/packages/orion/src/Input/input.css
+++ b/packages/orion/src/Input/input.css
@@ -1,60 +1,60 @@
-.ui.input {
+.orion.input {
   @apply inline-flex relative;
 }
-.ui.input > input {
+.orion.input > input {
   @apply h-48 pl-16 flex justify-center outline-none;
 }
 
-.ui.input:not(.labeled) > input {
+.orion.input:not(.labeled) > input {
   @apply bg-white border border-gray-900-24 rounded;
 }
 
-.ui.input > input:disabled {
+.orion.input > input:disabled {
   @apply bg-gray-900-8 pointer-events-none;
 }
 
-.ui.input > input:hover {
+.orion.input > input:hover {
   @apply shadow-field-hover;
 }
 
-.ui.input > input:active,
-.ui.input > input:focus {
+.orion.input > input:active,
+.orion.input > input:focus {
   @apply shadow-field-active;
 }
 
-.ui.input.small > input {
+.orion.input.small > input {
   @apply h-32;
 }
 
 /* Error */
-.ui.input.error > input {
+.orion.input.error > input {
   @apply border-magenta-500;
 }
 
-.ui.input.error > input:hover {
+.orion.input.error > input:hover {
   @apply shadow-error-field-hover;
 }
 
-.ui.input.error > input:active,
-.ui.input.error > input:focus {
+.orion.input.error > input:active,
+.orion.input.error > input:focus {
   @apply shadow-error-field-active;
 }
 
 /* Warning */
-.ui.input.warning > input {
+.orion.input.warning > input {
   @apply border-yellow-500;
 }
 
-.ui.input.warning > input:hover {
+.orion.input.warning > input:hover {
   @apply shadow-warning-field-hover;
 }
 
-.ui.input.warning > input:active,
-.ui.input.warning > input:focus {
+.orion.input.warning > input:active,
+.orion.input.warning > input:focus {
   @apply shadow-warning-field-active;
 }
 
-.ui.input.fluid > input {
+.orion.input.fluid > input {
   @apply w-full;
 }
 
@@ -62,10 +62,10 @@
  * Icon
  */
 
-.ui.input.icon > input {
+.orion.input.icon > input {
   @apply pr-40;
 }
 
-.ui.input.icon > input ~ .icon {
+.orion.input.icon > input ~ .icon {
   @apply absolute right-0 w-40 h-full flex items-center justify-center;
 }

--- a/packages/orion/src/Label/index.js
+++ b/packages/orion/src/Label/index.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import cx from 'classnames'
 import React from 'react'
-import { Label as SemanticLabel } from 'semantic-ui-react'
+import { Label as SemanticLabel } from '@inloco/semantic-ui-react'
 
 import Icon from '../Icon'
 import { createShorthandFactory } from '../utils/factories'

--- a/packages/orion/src/Label/label.css
+++ b/packages/orion/src/Label/label.css
@@ -1,12 +1,12 @@
-.ui.label {
+.orion.label {
   @apply inline-flex items-center px-8 bg-gray-900-8 rounded leading-20 text-gray-900 h-32;
 }
 
-.ui.label.small {
+.orion.label.small {
   @apply h-24;
 }
 
-.ui.label > i.icon {
+.orion.label > i.icon {
   @apply flex items-center mr-4;
 }
 
@@ -24,6 +24,6 @@
   @apply bg-gray-900-16;
 }
 
-.ui.label.small .label-remove {
+.orion.label.small .label-remove {
   @apply -ml-8 rounded-r-none;
 }

--- a/packages/orion/src/Layout/index.js
+++ b/packages/orion/src/Layout/index.js
@@ -8,7 +8,7 @@ import LayoutMain from './LayoutMain'
 import LayoutTopbar from './LayoutTopbar'
 
 const Layout = ({ className, children, ...otherProps }) => {
-  const classes = cx('ui layout', className)
+  const classes = cx('orion layout', className)
   return (
     <div className={classes} {...otherProps}>
       {children}

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -1,30 +1,30 @@
-.ui.layout {
+.orion.layout {
   @apply bg-gray-50 flex flex-col min-h-screen items-center relative;
 }
 
-.ui.layout .layout-center {
+.orion.layout .layout-center {
   @apply flex justify-center w-full;
 }
 
-.ui.layout .layout-center-content {
+.orion.layout .layout-center-content {
   @apply mx-24 w-full;
   max-width: 1024px;
 }
 
-.ui.layout .layout-topbar {
+.orion.layout .layout-topbar {
   @apply fixed top-0 left-0 z-40;
   @apply flex-shrink-0 items-center h-48 bg-white;
   @apply border-b-1 border-gray-900-16;
 }
 
-.ui.layout .layout-topbar > .layout-center-content {
+.orion.layout .layout-topbar > .layout-center-content {
   @apply flex items-center;
 }
 
-.ui.layout .layout-topbar .ui.menu {
+.orion.layout .layout-topbar .orion.menu {
   @apply flex-1 ml-40;
 }
 
-.ui.layout .layout-main {
+.orion.layout .layout-main {
   @apply flex-1 py-24 mt-48;
 }

--- a/packages/orion/src/Loading/index.js
+++ b/packages/orion/src/Loading/index.js
@@ -7,7 +7,7 @@ import { Sizes, sizePropType } from '../utils/sizes'
 import animationData from './animationData'
 
 const Loading = ({ className, inline, size, ...otherProps }) => {
-  const classes = cx('ui loading-spinner', className, size, {
+  const classes = cx('orion loading-spinner', className, size, {
     'loading-spinner-inline': inline
   })
   return (

--- a/packages/orion/src/Loading/loading.css
+++ b/packages/orion/src/Loading/loading.css
@@ -1,11 +1,11 @@
-.ui.loading-spinner {
+.orion.loading-spinner {
   @apply h-full mx-auto w-48;
 }
 
-.ui.loading-spinner.small {
+.orion.loading-spinner.small {
   width: 20px;
 }
 
-.ui.loading-spinner-inline {
+.orion.loading-spinner-inline {
   @apply h-auto m-0;
 }

--- a/packages/orion/src/Menu/index.js
+++ b/packages/orion/src/Menu/index.js
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import React from 'react'
-import { Menu as SemanticMenu } from 'semantic-ui-react'
+import { Menu as SemanticMenu } from '@inloco/semantic-ui-react'
 
 const Menu = ({ className, switcher, ...otherProps }) => (
   <SemanticMenu className={cx(className, { switcher })} {...otherProps} />

--- a/packages/orion/src/Menu/menu.css
+++ b/packages/orion/src/Menu/menu.css
@@ -1,61 +1,61 @@
 @import './switcher.css';
 
-.ui.menu {
+.orion.menu {
   @apply flex font-default;
 }
 
-.ui.menu .item {
+.orion.menu .item {
   @apply cursor-pointer flex items-center ml-40 outline-none text-base text-gray-800;
 }
 
-.ui.menu .item:hover,
-.ui.menu .item:focus {
+.orion.menu .item:hover,
+.orion.menu .item:focus {
   @apply text-gray-700;
 }
 
-.ui.menu .item:active {
+.orion.menu .item:active {
   @apply text-gray-900;
 }
 
-.ui.menu .item:first-child {
+.orion.menu .item:first-child {
   @apply ml-0;
 }
 
-.ui.menu .item.active {
+.orion.menu .item.active {
   @apply font-medium text-space-900;
 }
 
-.ui.menu .item.right {
+.orion.menu .item.right {
   @apply ml-auto;
 }
 
-.ui.menu .menu.right {
+.orion.menu .menu.right {
   @apply flex ml-auto;
 }
 
 /** Menu item with icon **/
 
-.ui.menu .item > .icon {
+.orion.menu .item > .icon {
   @apply mr-4 text-gray-700;
 }
 
-.ui.menu .item > svg.icon {
+.orion.menu .item > svg.icon {
   @apply fill-gray-700;
 }
 
-.ui.menu .item:hover > svg.icon,
-.ui.menu .item:focus > svg.icon {
+.orion.menu .item:hover > svg.icon,
+.orion.menu .item:focus > svg.icon {
   @apply fill-gray-700;
 }
 
-.ui.menu .item:active > svg.icon {
+.orion.menu .item:active > svg.icon {
   @apply fill-gray-900;
 }
 
-.ui.menu .item.active > .icon {
+.orion.menu .item.active > .icon {
   @apply text-space-600;
 }
 
-.ui.menu .item.active > svg.icon {
+.orion.menu .item.active > svg.icon {
   @apply fill-space-600;
 }

--- a/packages/orion/src/Menu/switcher.css
+++ b/packages/orion/src/Menu/switcher.css
@@ -1,21 +1,21 @@
-.ui.menu.switcher .item {
+.orion.menu.switcher .item {
   @apply h-32 ml-8 outline-none px-8 rounded transition-default;
   transition-property: background-color, color;
 }
 
-.ui.menu.switcher .item:first-child {
+.orion.menu.switcher .item:first-child {
   @apply ml-0;
 }
 
-.ui.menu.switcher .item:not(.active):hover,
-.ui.menu.switcher .item:not(.active):focus {
+.orion.menu.switcher .item:not(.active):hover,
+.orion.menu.switcher .item:not(.active):focus {
   @apply bg-gray-900-8;
 }
 
-.ui.menu.switcher .item:not(.active):active {
+.orion.menu.switcher .item:not(.active):active {
   @apply bg-gray-900-16;
 }
 
-.ui.menu.switcher .item.active {
+.orion.menu.switcher .item.active {
   @apply bg-space-100 font-normal;
 }

--- a/packages/orion/src/Message/index.js
+++ b/packages/orion/src/Message/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import { Message as SemanticMessage } from 'semantic-ui-react'
+import { Message as SemanticMessage } from '@inloco/semantic-ui-react'
 
 import Icon from '../Icon'
 

--- a/packages/orion/src/Message/message.css
+++ b/packages/orion/src/Message/message.css
@@ -1,24 +1,24 @@
-.ui.message {
+.orion.message {
   @apply border-1 border-green-500 rounded bg-green-50 p-16 text-base flex items-center;
 }
 
-.ui.message .header {
+.orion.message .header {
   @apply font-medium;
 }
 
-.ui.message.error {
+.orion.message.error {
   @apply border-magenta-500 bg-magenta-50;
 }
 
-.ui.message.warning {
+.orion.message.warning {
   @apply border-yellow-500 bg-yellow-50;
 }
 
-.ui.message > .icon:not(.close) {
+.orion.message > .icon:not(.close) {
   @apply pr-4;
 }
 
-.ui.message.header > .icon {
+.orion.message.header > .icon {
   @apply pr-16;
 }
 

--- a/packages/orion/src/Popup/popup.css
+++ b/packages/orion/src/Popup/popup.css
@@ -1,8 +1,8 @@
-.ui.popup {
+.orion.popup {
   @apply bg-white border border-gray-900-8 leading-14 p-16 rounded shadow-300 text-gray-800 z-50;
 }
 
-.ui.popup:before {
+.orion.popup:before {
   @apply absolute bg-white;
 
   content: '';
@@ -11,70 +11,70 @@
   width: 12px;
 }
 
-.ui.popup.small {
+.orion.popup.small {
   @apply text-sm;
 }
 
 /** Positions **/
 
-.ui.popup.top {
+.orion.popup.top {
   @apply mb-8;
 }
 
-.ui.popup.bottom {
+.orion.popup.bottom {
   @apply mt-8;
 }
 
-.ui.popup.left.center {
+.orion.popup.left.center {
   @apply mr-8;
 }
 
-.ui.popup.right.center {
+.orion.popup.right.center {
   @apply ml-8;
 }
 
-.ui.popup.top:before {
+.orion.popup.top:before {
   @apply top-auto right-auto;
   bottom: -6px;
   box-shadow: 1px 1px 0 0 rgba(61, 62, 63, 0.08);
 }
 
-.ui.popup.bottom:before {
+.orion.popup.bottom:before {
   @apply bottom-auto right-auto;
   top: -6px;
   box-shadow: -1px -1px 0 0 rgba(61, 62, 63, 0.08);
 }
 
-.ui.popup.left:before {
+.orion.popup.left:before {
   left: 10px;
 }
 
-.ui.popup.right:before {
+.orion.popup.right:before {
   @apply left-auto;
 
   right: 10px;
 }
 
-.ui.popup.top.center:before,
-.ui.popup.bottom.center:before {
+.orion.popup.top.center:before,
+.orion.popup.bottom.center:before {
   left: 50%;
   margin-left: -6px;
 }
 
-.ui.popup.left.center:before,
-.ui.popup.right.center:before {
+.orion.popup.left.center:before,
+.orion.popup.right.center:before {
   @apply bottom-auto;
   margin-top: -6px;
   top: 50%;
 }
 
-.ui.popup.left.center:before {
+.orion.popup.left.center:before {
   @apply left-auto;
   right: -6px;
   box-shadow: 1px -1px 0 0 rgba(61, 62, 63, 0.08);
 }
 
-.ui.popup.right.center:before {
+.orion.popup.right.center:before {
   @apply right-auto;
   left: -6px;
   box-shadow: -1px 1px 0 0 rgba(61, 62, 63, 0.08);
@@ -82,10 +82,10 @@
 
 /** Basic (not pointing) **/
 
-.ui.popup.basic {
+.orion.popup.basic {
   @apply border-gray-900-16 shadow-200 text-gray-900;
 }
 
-.ui.popup.basic:before {
+.orion.popup.basic:before {
   @apply hidden;
 }

--- a/packages/orion/src/Progress/index.js
+++ b/packages/orion/src/Progress/index.js
@@ -8,7 +8,7 @@ import { Sizes, sizePropType } from '../utils/sizes'
 const Progress = ({ className, color, percent, size, ...otherProps }) => {
   return (
     <div
-      className={cx(className, size, 'ui progress')}
+      className={cx(className, size, 'orion progress')}
       data-percent={percent}
       {...otherProps}>
       <div className={`bar bg-${color}`} style={{ width: `${percent}%` }} />

--- a/packages/orion/src/Progress/progress.css
+++ b/packages/orion/src/Progress/progress.css
@@ -1,12 +1,12 @@
-.ui.progress {
+.orion.progress {
   @apply bg-gray-900-8 rounded-small;
 }
 
-.ui.progress .bar {
+.orion.progress .bar {
   @apply h-24 rounded-small transition-default;
   transition-property: width;
 }
 
-.ui.progress.small .bar {
+.orion.progress.small .bar {
   @apply h-4;
 }

--- a/packages/orion/src/RangedDatepicker/index.js
+++ b/packages/orion/src/RangedDatepicker/index.js
@@ -29,7 +29,7 @@ const RangedDatepicker = ({
   }
 
   return (
-    <div className="ui ranged-datepicker">
+    <div className="orion ranged-datepicker">
       <ReactDatesDatepicker
         as={DayPickerRangeController}
         startDate={toMoment(_.get(dates, 'startDate'))}

--- a/packages/orion/src/RangedDatepicker/rangedDatepicker.css
+++ b/packages/orion/src/RangedDatepicker/rangedDatepicker.css
@@ -1,4 +1,4 @@
-.ui.ranged-datepicker {
+.orion.ranged-datepicker {
   @apply -mx-24;
 }
 

--- a/packages/orion/src/Search/search.css
+++ b/packages/orion/src/Search/search.css
@@ -1,36 +1,36 @@
-.ui.search {
+.orion.search {
   @apply relative inline-block h-48;
 }
 
-.ui.search.small {
+.orion.search.small {
   @apply h-32;
 }
 
-.ui.search > .ui.input {
+.orion.search > .orion.input {
   @apply h-full;
 }
 
-.ui.search > .ui.input > input {
+.orion.search > .orion.input > input {
   @apply h-full !important;
 }
 
-.ui.search .results {
+.orion.search .results {
   @apply absolute hidden mt-8 shadow-200 left-0 w-full;
   top: 100%;
 }
 
-.ui.search.active .results {
+.orion.search.active .results {
   @apply block rounded;
 }
 
-.ui.search .results > .result {
+.orion.search .results > .result {
   @apply px-16 py-8 cursor-pointer;
 }
 
-.ui.search .results > .result.active {
+.orion.search .results > .result.active {
   @apply font-medium;
 }
 
-.ui.search .results > .result:hover {
+.orion.search .results > .result:hover {
   @apply bg-gray-900-4;
 }

--- a/packages/orion/src/Tooltip/index.js
+++ b/packages/orion/src/Tooltip/index.js
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import React from 'react'
-import { Popup } from 'semantic-ui-react'
+import { Popup } from '@inloco/semantic-ui-react'
 
 import { Sizes } from '../utils/sizes'
 

--- a/packages/orion/src/Tooltip/tooltip.css
+++ b/packages/orion/src/Tooltip/tooltip.css
@@ -1,7 +1,7 @@
-.ui.popup.tooltip {
+.orion.popup.tooltip {
   @apply bg-gray-800 p-8 text-white;
 }
 
-.ui.popup.tooltip:before {
+.orion.popup.tooltip:before {
   @apply bg-gray-800;
 }

--- a/packages/orion/src/index.js
+++ b/packages/orion/src/index.js
@@ -5,7 +5,7 @@ export {
   Popup,
   Search,
   Select
-} from 'semantic-ui-react'
+} from '@inloco/semantic-ui-react'
 
 export { default as Button } from './Button'
 export { default as ClickOutside } from './ClickOutside'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,10 +1331,10 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
-"@inloco/semantic-ui-react@^0.87.3-beta.1":
-  version "0.87.3-beta.1"
-  resolved "https://registry.yarnpkg.com/@inloco/semantic-ui-react/-/semantic-ui-react-0.87.3-beta.1.tgz#c83a3317207e3808f43cb587db21eae1139b6862"
-  integrity sha512-leefc1T3T/ZJmbq+Jfr56zrodJRAvQCdFRKwiFpegMEMalvspiUfDNsYxUG2hz1SB+tbKaHnzK/9VEJk1V+iyw==
+"@inloco/semantic-ui-react@^0.87.3":
+  version "0.87.3"
+  resolved "https://registry.yarnpkg.com/@inloco/semantic-ui-react/-/semantic-ui-react-0.87.3.tgz#5922122089314b83e476d3090647e99009bec6e8"
+  integrity sha512-Z6eJ7yfH7SqzudHCfcLjBGPemUzrAEdbZBhkhzdk171JBLN6p19txvB4hw9x4YoAbf8e7vYAcSJTNdiliNMNgA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@semantic-ui-react/event-stack" "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,6 +1331,21 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
+"@inloco/semantic-ui-react@^0.87.3-beta.1":
+  version "0.87.3-beta.1"
+  resolved "https://registry.yarnpkg.com/@inloco/semantic-ui-react/-/semantic-ui-react-0.87.3-beta.1.tgz#c83a3317207e3808f43cb587db21eae1139b6862"
+  integrity sha512-leefc1T3T/ZJmbq+Jfr56zrodJRAvQCdFRKwiFpegMEMalvspiUfDNsYxUG2hz1SB+tbKaHnzK/9VEJk1V+iyw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    "@semantic-ui-react/event-stack" "^3.1.0"
+    classnames "^2.2.6"
+    keyboard-key "^1.0.4"
+    lodash "^4.17.11"
+    prop-types "^15.6.2"
+    react-is "^16.7.0"
+    react-popper "^1.3.3"
+    shallowequal "^1.1.0"
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
@@ -12356,7 +12371,7 @@ react-docgen@^4.1.0:
     node-dir "^0.1.10"
     recast "^0.17.3"
 
-react-dom@^16.8.3, react-dom@^16.9.0:
+react-dom@^16.8.3:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
   integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
@@ -12586,7 +12601,7 @@ react-with-styles@^3.2.3:
     prop-types "^15.6.2"
     react-with-direction "^1.3.0"
 
-react@^16.8.3, react@^16.9.0:
+react@^16.8.3:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
   integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
@@ -13310,21 +13325,6 @@ select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
   integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
-
-semantic-ui-react@^0.87.2:
-  version "0.87.3"
-  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-0.87.3.tgz#59b6e1ca52b202bf6deed4c65e81b170b4a12bf6"
-  integrity sha512-YJgFYEheeFBMm/epZpIpWKF9glgSShdLPiY8zoUi+KJ0IKtLtbI8RbMD/ELbZkY+SO/IWbK/f/86pWt3PVvMVA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    "@semantic-ui-react/event-stack" "^3.1.0"
-    classnames "^2.2.6"
-    keyboard-key "^1.0.4"
-    lodash "^4.17.11"
-    prop-types "^15.6.2"
-    react-is "^16.7.0"
-    react-popper "^1.3.3"
-    shallowequal "^1.1.0"
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Para não conflitar com o supernova, resolvemos forkar o projeto do [semantic-ui-react](https://github.com/inloco/Semantic-UI-React).

Em vez de usar o prefixo `ui` no componentes, ex: `className="ui dropdown"` ele usa `orion`. Ex:`className="orion dropdown"`.

Este PR está apenas renomeando os arquivos.
