### PR TITLE
fix(dimmer): Fix dimmer's background color

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -83,6 +83,9 @@ module.exports = {
       white: theme('colors').white,
       gray: {
         ..._.pick(theme('colors.gray'), ['50', '100', '200', '800']),
+        '50-80': Color(theme('colors').gray['50'])
+          .alpha(0.8)
+          .string(),
         '900-4': Color(theme('colors').gray['900'])
           .alpha(0.04)
           .string(),

--- a/packages/orion/src/Dimmer/dimmer.css
+++ b/packages/orion/src/Dimmer/dimmer.css
@@ -1,10 +1,10 @@
 .orion.dimmer {
-  @apply bg-gray-50 flex z-30;
+  @apply bg-gray-50-80 flex z-30;
   @apply absolute top-0 left-0 w-full h-full;
   @apply transition-default opacity-0 pointer-events-none;
   transition-property: opacity;
 }
 
 .orion.dimmer.active {
-  @apply opacity-80 pointer-events-auto;
+  @apply opacity-100 pointer-events-auto;
 }


### PR DESCRIPTION
Eu havia feito o dimmer usando a regra `opacity` pra deixá-lo transparente, mas não percebi que isso iria deixar qualquer conteúdo dele, mesmo com `position: absolute`, transparente também. É o caso do modal, que estava mostrando conteúdo por trás dele.

Troquei o `opacity` por `background-color` já em `rgba` e agora o modal é fosco como esperado, apenas o dimmer tendo transparência.

**Antes**
<img width="750" alt="Screen Shot 2019-08-21 at 10 32 34 AM" src="https://user-images.githubusercontent.com/5216049/63437135-641a4c80-c400-11e9-8ea6-4c59e942611a.png">

**Depois**
<img width="756" alt="Screen Shot 2019-08-21 at 10 32 22 AM" src="https://user-images.githubusercontent.com/5216049/63437134-641a4c80-c400-11e9-9401-264be4305624.png">
