### PR TITLE
feature(layout-topbar-enhancement): Resize topbar height and menu items margin

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -76,7 +76,8 @@ module.exports = {
       '24': '24px',
       '32': '32px',
       '40': '40px',
-      '48': '48px'
+      '48': '48px',
+      '64': '64px'
     },
 
     backgroundColor: theme => ({

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -13,7 +13,7 @@
 
 .orion.layout .layout-topbar {
   @apply fixed top-0 left-0 z-40;
-  @apply flex-shrink-0 items-center h-48 bg-white;
+  @apply flex-shrink-0 items-center h-64 bg-white;
   @apply border-b-1 border-gray-900-16;
 }
 

--- a/packages/orion/src/Menu/menu.css
+++ b/packages/orion/src/Menu/menu.css
@@ -5,7 +5,7 @@
 }
 
 .orion.menu .item {
-  @apply cursor-pointer flex items-center ml-40 outline-none text-base text-gray-800;
+  @apply cursor-pointer flex items-center ml-24 outline-none text-base text-gray-800;
 }
 
 .orion.menu .item:hover,


### PR DESCRIPTION
Flora me passou o Invision do novo `topbar` do 4apps:

![image](https://user-images.githubusercontent.com/1139664/63695495-3281f680-c7ef-11e9-889b-af1c0a14c5ec.png)

Duas coisas mudaram em relação ao que estava especificado anteriormente:

- O `topbar` agora tem 64px em vez de 48px. Ela confirmou com Bruno que é realmente pra mudar.
- A distância entre os itens de menu mudou de 40px pra 24px.

Antes:
![image](https://user-images.githubusercontent.com/1139664/63695646-868cdb00-c7ef-11e9-8c7e-fe3b993f5496.png)

Depois:
![image](https://user-images.githubusercontent.com/1139664/63695680-94daf700-c7ef-11e9-91f4-31cce89606c7.png)

