### PR TITLE
feature(table): Remove vertical padding from table cells

### DIFF
--- a/packages/orion/src/Table/Table.stories.js
+++ b/packages/orion/src/Table/Table.stories.js
@@ -40,14 +40,18 @@ storiesOf('Table', module)
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell></Table.HeaderCell>
-            <Table.HeaderCell className="text-center w-384" colspan="2" divider>
+            <Table.HeaderCell
+              className="w-384"
+              horizontalAlign="center"
+              colSpan="2"
+              divider>
               Visits
             </Table.HeaderCell>
           </Table.Row>
           <Table.Row>
             <Table.HeaderCell>Name</Table.HeaderCell>
-            <Table.HeaderCell className="text-center">Count</Table.HeaderCell>
-            <Table.HeaderCell className="text-center">
+            <Table.HeaderCell horizontalAlign="center">Count</Table.HeaderCell>
+            <Table.HeaderCell horizontalAlign="center">
               vs Comparison Average
             </Table.HeaderCell>
           </Table.Row>
@@ -55,13 +59,13 @@ storiesOf('Table', module)
         <Table.Body>
           <Table.Row>
             <Table.Cell>Loja de sorvete da esquina</Table.Cell>
-            <Table.Cell className="text-center">30</Table.Cell>
-            <Table.Cell className="text-center">-15</Table.Cell>
+            <Table.Cell horizontalAlign="center">30</Table.Cell>
+            <Table.Cell horizontalAlign="center">-15</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>Mercadinho da esquina</Table.Cell>
-            <Table.Cell className="text-center">45</Table.Cell>
-            <Table.Cell className="text-center">+15</Table.Cell>
+            <Table.Cell horizontalAlign="center">45</Table.Cell>
+            <Table.Cell horizontalAlign="center">+15</Table.Cell>
           </Table.Row>
         </Table.Body>
       </Table>
@@ -74,10 +78,10 @@ storiesOf('Table', module)
           <Table.Row></Table.Row>
           <Table.Row>
             <Table.HeaderCell>Name</Table.HeaderCell>
-            <Table.HeaderCell className="text-right">
+            <Table.HeaderCell horizontalAlign="right">
               Visits Share
             </Table.HeaderCell>
-            <Table.HeaderCell className="text-right">
+            <Table.HeaderCell horizontalAlign="right">
               Region Potential
             </Table.HeaderCell>
           </Table.Row>
@@ -85,17 +89,17 @@ storiesOf('Table', module)
         <Table.Body>
           <Table.Row>
             <Table.Cell>Loja de sorvete da esquina</Table.Cell>
-            <Table.Cell className="text-right" highlight>
+            <Table.Cell horizontalAlign="right" highlight>
               30%
             </Table.Cell>
-            <Table.Cell className="text-right">0.32</Table.Cell>
+            <Table.Cell horizontalAlign="right">0.32</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>Mercadinho da esquina</Table.Cell>
-            <Table.Cell className="text-right" highlight>
+            <Table.Cell horizontalAlign="right" highlight>
               45%
             </Table.Cell>
-            <Table.Cell className="text-right">0.67</Table.Cell>
+            <Table.Cell horizontalAlign="right">0.67</Table.Cell>
           </Table.Row>
         </Table.Body>
       </Table>

--- a/packages/orion/src/Table/TableCell/index.js
+++ b/packages/orion/src/Table/TableCell/index.js
@@ -1,23 +1,35 @@
 import cx from 'classnames'
 import { Table } from '@inloco/semantic-ui-react'
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
+
+import { HorizontalAlignValues } from '../constants'
+
+const ALIGN_TO_JUSTIFY_CONTENT = {
+  [HorizontalAlignValues.LEFT]: 'justify-start',
+  [HorizontalAlignValues.CENTER]: 'justify-center',
+  [HorizontalAlignValues.RIGHT]: 'justify-end'
+}
 
 const TableCell = ({
   children,
   className,
   content,
   highlight,
+  horizontalAlign,
   ...otherProps
 }) => {
-  const classes = cx(className, { highlight })
+  const classes = cx('orion inner-cell', className, {
+    highlight,
+    [ALIGN_TO_JUSTIFY_CONTENT[horizontalAlign]]: !!horizontalAlign
+  })
   const childContent = content || children
   return (
     <Table.Cell
-      className={classes}
       title={_.isString(childContent) ? childContent : null}
       {...otherProps}>
-      <div className="orion inner-cell">
+      <div className={classes}>
         <div className="orion inner-cell-wrapper">{childContent}</div>
       </div>
     </Table.Cell>
@@ -28,7 +40,8 @@ TableCell.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   content: PropTypes.node,
-  highlight: PropTypes.bool
+  highlight: PropTypes.bool,
+  horizontalAlign: PropTypes.oneOf(_.values(HorizontalAlignValues))
 }
 
 export default TableCell

--- a/packages/orion/src/Table/TableHeaderCell/index.js
+++ b/packages/orion/src/Table/TableHeaderCell/index.js
@@ -1,22 +1,35 @@
+import cx from 'classnames'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import { Table } from '@inloco/semantic-ui-react'
 import React from 'react'
 
+import { HorizontalAlignValues } from '../constants'
 import Divider from '../../Divider'
 
-const TableHeaderCell = ({ children, divider, ...otherProps }) => (
-  <Table.HeaderCell
-    title={_.isString(children) ? children : null}
-    {...otherProps}>
-    <div className="orion inner-cell">{children}</div>
-    {divider === true ? <Divider /> : divider}
-  </Table.HeaderCell>
-)
+const TableHeaderCell = ({
+  children,
+  className,
+  divider,
+  horizontalAlign,
+  ...otherProps
+}) => {
+  const classes = cx(className, horizontalAlign && `text-${horizontalAlign}`)
+  return (
+    <Table.HeaderCell
+      className={classes}
+      title={_.isString(children) ? children : null}
+      {...otherProps}>
+      <div className="orion inner-cell">{children}</div>
+      {divider === true ? <Divider /> : divider}
+    </Table.HeaderCell>
+  )
+}
 
 TableHeaderCell.propTypes = {
   children: PropTypes.node,
-  divider: PropTypes.oneOfType([PropTypes.node, PropTypes.bool])
+  divider: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
+  horizontalAlign: PropTypes.oneOf(_.values(HorizontalAlignValues))
 }
 
 export default TableHeaderCell

--- a/packages/orion/src/Table/constants.js
+++ b/packages/orion/src/Table/constants.js
@@ -1,0 +1,5 @@
+export const HorizontalAlignValues = {
+  LEFT: 'left',
+  CENTER: 'center',
+  RIGHT: 'right'
+}

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -58,15 +58,12 @@
 }
 
 .orion.table tbody > tr > td > .inner-cell {
-  @apply bg-white truncate;
+  @apply bg-white flex items-center truncate;
   @apply border-t-1 border-b-1 border-gray-900-8;
   @apply px-12 mt-8;
+  height: 54px;
 }
 
-.orion.table tbody > tr > td .inner-cell-wrapper {
-  @apply inline-block py-16;
-}
-
-.orion.table tbody > tr > td.highlight .inner-cell-wrapper {
-  @apply bg-gray-900-4 px-16;
+.orion.table tbody .inner-cell.highlight > .inner-cell-wrapper {
+  @apply bg-gray-900-4 flex items-center h-full px-16;
 }


### PR DESCRIPTION
Ao invés de determinar o height de cada row/column indiretamente através do fontsize + padding, estou definindo o height de forma mais fixa aqui e centralizando verticalmente o conteúdo.

Por enquanto queremos de fato que essas linhas não fiquem mais altas que isso (tanto que adicionei o `truncate` no último pr), então não precisamos de flexibilidade nessa altura. Pelo contrário, queremos que seja sempre igual.

E usando padding não estava sendo possível ter conteúdo maior do que apenas texto em cada coluna, causando problemas como no screenshot abaixo (esse foi o motivo principal pra fazer o pr na verdade):

**Antes**
<img width="1039" alt="Screen Shot 2019-08-28 at 3 23 57 PM" src="https://user-images.githubusercontent.com/5216049/63882510-871ca180-c9a8-11e9-89c8-7cf771756e9e.png">

**Depois**
<img width="1036" alt="Screen Shot 2019-08-28 at 3 24 09 PM" src="https://user-images.githubusercontent.com/5216049/63882511-87b53800-c9a8-11e9-88fd-a58f4ade9014.png">