### PR TITLE
fix(dropdown): Add padding only when it is a selection

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -2,7 +2,7 @@
 
 .orion.dropdown {
   @apply flex-wrap inline-flex items-center relative;
-  @apply cursor-pointer min-h-48 px-16 outline-none select-none;
+  @apply cursor-pointer min-h-48 outline-none select-none;
   min-width: 256px;
 }
 
@@ -147,7 +147,7 @@
  */
 
 .orion.dropdown.selection {
-  @apply bg-white border border-gray-900-24 rounded;
+  @apply bg-white border border-gray-900-24 px-16 rounded;
 }
 
 .orion.dropdown.selection.small {


### PR DESCRIPTION
Só adicionamos padding horizontal quando o Dropdown é um selection:

Antes:
![image](https://user-images.githubusercontent.com/1139664/64128801-ce32da00-cd8e-11e9-8d28-9d2ad663a36d.png)


Depois:
![image](https://user-images.githubusercontent.com/1139664/64128804-d68b1500-cd8e-11e9-88be-4ff65a8da6a7.png)
