### PR TITLE
feature(table): Change highlight feature to highlight the whole cell

### DIFF
--- a/packages/orion/src/Table/Table.stories.js
+++ b/packages/orion/src/Table/Table.stories.js
@@ -59,47 +59,17 @@ storiesOf('Table', module)
         <Table.Body>
           <Table.Row>
             <Table.Cell>Loja de sorvete da esquina</Table.Cell>
-            <Table.Cell horizontalAlign="center">30</Table.Cell>
+            <Table.Cell horizontalAlign="center" highlight>
+              30
+            </Table.Cell>
             <Table.Cell horizontalAlign="center">-15</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>Mercadinho da esquina</Table.Cell>
-            <Table.Cell horizontalAlign="center">45</Table.Cell>
+            <Table.Cell horizontalAlign="center" highlight>
+              45
+            </Table.Cell>
             <Table.Cell horizontalAlign="center">+15</Table.Cell>
-          </Table.Row>
-        </Table.Body>
-      </Table>
-    )
-  })
-  .add('Highlight', () => {
-    return (
-      <Table>
-        <Table.Header>
-          <Table.Row></Table.Row>
-          <Table.Row>
-            <Table.HeaderCell>Name</Table.HeaderCell>
-            <Table.HeaderCell horizontalAlign="right">
-              Visits Share
-            </Table.HeaderCell>
-            <Table.HeaderCell horizontalAlign="right">
-              Region Potential
-            </Table.HeaderCell>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          <Table.Row>
-            <Table.Cell>Loja de sorvete da esquina</Table.Cell>
-            <Table.Cell horizontalAlign="right" highlight>
-              30%
-            </Table.Cell>
-            <Table.Cell horizontalAlign="right">0.32</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Mercadinho da esquina</Table.Cell>
-            <Table.Cell horizontalAlign="right" highlight>
-              45%
-            </Table.Cell>
-            <Table.Cell horizontalAlign="right">0.67</Table.Cell>
           </Table.Row>
         </Table.Body>
       </Table>

--- a/packages/orion/src/Table/TableCell/index.js
+++ b/packages/orion/src/Table/TableCell/index.js
@@ -29,9 +29,7 @@ const TableCell = ({
     <Table.Cell
       title={_.isString(childContent) ? childContent : null}
       {...otherProps}>
-      <div className={classes}>
-        <div className="orion inner-cell-wrapper">{childContent}</div>
-      </div>
+      <div className={classes}>{childContent}</div>
     </Table.Cell>
   )
 }

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -58,16 +58,12 @@
 }
 
 .orion.table tbody > tr > td > .inner-cell {
-  @apply bg-white flex items-center;
+  @apply bg-white flex items-center truncate;
   @apply border-t-1 border-b-1 border-gray-900-8;
   @apply px-12 mt-8;
   height: 54px;
 }
 
-.orion.table tbody .inner-cell > .inner-cell-wrapper {
-  @apply truncate;
-}
-
-.orion.table tbody .inner-cell.highlight > .inner-cell-wrapper {
-  @apply bg-gray-900-4 flex items-center h-full px-16;
+.orion.table tbody > tr > td > .inner-cell.highlight {
+  @apply bg-gray-900-4;
 }


### PR DESCRIPTION
Nos dois lugares do Invision em que eu tinha visto o nosso uso de `highlight` pra table headers, me pareceu que nós não estávamos fazendo o highlight na célula inteira, mas apenas ao redor do tamanho do conteúdo. Por isso fiz o highlight em um elemento `inline-block` com padding.

Porém, notei que isso causa problemas porque o conteúdo de células da mesma coluna pode variar de tamanho, e então o highlight variava também e ficava esquisito. Olhando melhor o Invision, notei que na verdade as duas telas estavam usando width fixo pra essa área do highlight, ao invés de ser sempre o tamanho do conteúdo.

Ou seja, o uso do highlight pode variar de tabela em tabela, e deixando o elemento com `inline-block` forçava esses usos a sobrescreverem mais CSS do que se apenas adicionassem o highlight sozinhos.

Achei melhor então deixar o highlight cobrindo a coluna inteira. Pode ajudar em alguns casos e neles evitar ter que saber que cor usar nesse highlight mais comum. Mas em casos mais específicos é fácil adicionar na mão (só adicionar `bg-gray-900-4` num wrapper criado manualmente). Pensei em remover o `highlight` totalmente também, mas me parece que ainda pode ser útil, ao menos como referência, além de ser simples.

**Antes**
<img width="1218" alt="Screen Shot 2019-09-04 at 1 51 40 PM" src="https://user-images.githubusercontent.com/5216049/64275456-f3a11e80-cf1b-11e9-95da-fc7575d0ef08.png">

**Depois**
<img width="1217" alt="Screen Shot 2019-09-04 at 1 51 45 PM" src="https://user-images.githubusercontent.com/5216049/64275457-f3a11e80-cf1b-11e9-8b1a-7a2e62da8402.png">
