### PR TITLE
feature(table): Style the sortable table

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -216,7 +216,8 @@ module.exports = {
     },
     fontFamily: {
       default: ['neue-haas-grotesk-text', 'sans-serif'],
-      display: ['neue-haas-grotesk-display', 'sans-serif']
+      display: ['neue-haas-grotesk-display', 'sans-serif'],
+      icons: ['Material Icons']
     },
     fontSize: {
       sm: '12px',

--- a/packages/orion/src/Table/Table.stories.js
+++ b/packages/orion/src/Table/Table.stories.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { object, withKnobs } from '@storybook/addon-knobs'
+import { number, object, radios, withKnobs } from '@storybook/addon-knobs'
 
 import { Table } from '../'
 
@@ -71,6 +71,40 @@ storiesOf('Table', module)
             </Table.Cell>
             <Table.Cell horizontalAlign="center">+15</Table.Cell>
           </Table.Row>
+        </Table.Body>
+      </Table>
+    )
+  })
+  .add('Sortable', () => {
+    const headers = object('Headers', DEFAULT_HEADERS)
+    const data = object('Data', DEFAULT_DATA)
+    const sortableColumnIndex = number('Sortable Column Index', 0)
+    const order = radios(
+      'Order',
+      { Ascending: 'ascending', Descending: 'descending' },
+      'ascending'
+    )
+    return (
+      <Table sortable>
+        <Table.Header>
+          <Table.Row>
+            {_.map(headers, (title, index) => (
+              <Table.HeaderCell
+                key={index}
+                sorted={sortableColumnIndex === index ? order : null}>
+                {title}
+              </Table.HeaderCell>
+            ))}
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {_.map(data, (row, index) => (
+            <Table.Row key={index}>
+              {_.map(row, (value, rowIndex) => (
+                <Table.Cell key={rowIndex}>{value}</Table.Cell>
+              ))}
+            </Table.Row>
+          ))}
         </Table.Body>
       </Table>
     )

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -71,3 +71,37 @@
 .orion.table tbody .inner-cell > .inner-cell-wrapper {
   @apply truncate;
 }
+
+/** Sortable **/
+
+.orion.table.sortable th {
+  @apply cursor-pointer;
+}
+
+.orion.table.sortable th:hover,
+.orion.table.sortable th:focus {
+  @apply text-gray-700;
+}
+
+.orion.table.sortable th:active {
+  @apply text-gray-900;
+}
+
+.orion.table.sortable th.sorted > .inner-cell::after {
+  @apply absolute ml-4 text-gray-700 text-lg transition-default font-icons;
+  content: 'keyboard_arrow_up';
+  transition-property: transform;
+}
+
+.orion.table.sortable th.sorted:hover > .inner-cell::after,
+.orion.table.sortable th.sorted:focus > .inner-cell::after {
+  @apply text-gray-800;
+}
+
+.orion.table.sortable th.sorted:active > .inner-cell::after {
+  @apply text-gray-900;
+}
+
+.orion.table.sortable th.sorted.descending > .inner-cell::after {
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
Estilizei nossa `Table` para quando ela é **sortable**. Lembrando que é só o estilo mesmo, o funcionamento não é implementado automaticamente pelo semantic (e é realmente complicado deixar genérico pra a maioria dos casos, estou achando melhor ter um hook pra ajudar com isso, provavelmente no repo do produto mesmo).


![2019-09-04 14 50 45](https://user-images.githubusercontent.com/5216049/64278595-82656980-cf23-11e9-837b-bb6e972abced.gif)
