### PR TITLE
fix(table): Change Table to easily allow custom cell content (like custom highlights)

### DIFF
--- a/packages/orion/src/Table/TableCell/index.js
+++ b/packages/orion/src/Table/TableCell/index.js
@@ -20,8 +20,8 @@ const TableCell = ({
   horizontalAlign,
   ...otherProps
 }) => {
-  const classes = cx('orion inner-cell', className, {
-    highlight,
+  const classes = cx('orion inner-cell', className, { highlight })
+  const wrapperClasses = cx('inner-cell-wrapper', {
     [ALIGN_TO_JUSTIFY_CONTENT[horizontalAlign]]: !!horizontalAlign
   })
   const childContent = content || children
@@ -30,7 +30,7 @@ const TableCell = ({
       title={_.isString(childContent) ? childContent : null}
       {...otherProps}>
       <div className={classes}>
-        <div className="inner-cell-wrapper">{childContent}</div>
+        <div className={wrapperClasses}>{childContent}</div>
       </div>
     </Table.Cell>
   )

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -58,18 +58,18 @@
 }
 
 .orion.table tbody > tr > td > .inner-cell {
-  @apply bg-white flex items-center truncate;
+  @apply bg-white;
   @apply border-t-1 border-b-1 border-gray-900-8;
   @apply px-12 mt-8;
   height: 54px;
 }
 
-.orion.table tbody > tr > td > .inner-cell.highlight {
-  @apply bg-gray-900-4;
+.orion.table tbody .inner-cell > .inner-cell-wrapper {
+  @apply flex items-center h-full truncate;
 }
 
-.orion.table tbody .inner-cell > .inner-cell-wrapper {
-  @apply truncate;
+.orion.table tbody .inner-cell.highlight > .inner-cell-wrapper {
+  @apply bg-gray-900-4;
 }
 
 /** Sortable **/


### PR DESCRIPTION
Ontem eu fiz um pr que simplificava nossa feature de highlight, deixando ela sempre cobrindo a célula inteira ao invés de tentar cobrir só o seu conteúdo. E em casos especiais, quem chama `Table` poderia fazer seu próprio highlight cobrindo o conteúdo que interessar.

A idéia é justamente essa, mas a execução não ficou perfeita. Isso porque eu precisei manter o `inner-cell-wrapper` por conta da lógica de text truncation (não dá pra fazer o truncation com um pai flex se o filho for texto puro, então eu mantive esse wrapper pra o pai sempre ter um filho e o caso mais comum já funcionar com text truncation).

Esse `inner-cell-wrapper` não estava cobrindo o width e o height inteiro da célula, porque seu pai era `flex` e estava posicionando ele. Isso impossibilita que a pessoa usando `Table` possa realmente customizar o conteúdo das células (inclusive o highlight), porque ela não tem mais o controle do height/width inteiros da célula. 

Pra corrigir isso, estou fazendo o `inner-cell-wrapper` sempre cobrir o height/width inteiros da célula, e ser quem controla o posicionamento (vertical e horizontal) do conteúdo com flex, além de ser quem possui o highlight. Pra todos os efeitos, ele é o elemento principal da célula, e o seu conteúdo vai poder ser customizado como desejado agora.

Visualmente nada mudou. Isso só permite mais customização nos conteúdos passados pra nossa `Table`, sem precisar sobrescrever nosso CSS.

PS.: Essas células da nossa `Table` estão dando um trabalhinho nesses detalhes... É tudo porque a gente precisou tratar de forma especial, tendo os headers colados enquanto as rows do body são separadas, então os layouts oferecidos por `<table>` não serviram e estamos tendo que usar flex nos conteúdos das células pra centralizar verticalmente... Mas (se Deus quiser 🙏) acredito que agora deve estar ok!

PS2.: Foi mal o textão. O código é bem pequeno, mas achei complicado de explicar o motivo da alteração.