### PR TITLE
fix(factories): Add missing factories from semantic ui to the components we're wrapping

### DIFF
--- a/packages/orion/src/Icon/index.js
+++ b/packages/orion/src/Icon/index.js
@@ -32,4 +32,6 @@ Icon.propTypes = {
 // Overriding original factory. See src/utils/factories.js for more details.
 SemanticIcon.create = createShorthandFactory(Icon, value => ({ name: value }))
 
+Icon.create = SemanticIcon.create
+
 export default Icon

--- a/packages/orion/src/Input/index.js
+++ b/packages/orion/src/Input/index.js
@@ -28,4 +28,6 @@ Input.defaultProps = {
 // Overriding original factory. See src/utils/factories.js for more details.
 SemanticInput.create = createShorthandFactory(Input, type => ({ type }))
 
+Input.create = SemanticInput.create
+
 export default Input

--- a/packages/orion/src/Label/index.js
+++ b/packages/orion/src/Label/index.js
@@ -48,4 +48,6 @@ SemanticLabel.create = createShorthandFactory(Label, value => ({
   content: value
 }))
 
+Label.create = SemanticLabel.create
+
 export default Label

--- a/packages/orion/src/Message/index.js
+++ b/packages/orion/src/Message/index.js
@@ -62,4 +62,7 @@ Message.defaultProps = {
   success: true
 }
 
+Message.Content = SemanticMessage.Content
+Message.Header = SemanticMessage.Header
+
 export default Message

--- a/packages/orion/src/Table/TableCell/index.js
+++ b/packages/orion/src/Table/TableCell/index.js
@@ -1,10 +1,11 @@
 import cx from 'classnames'
-import { Table } from '@inloco/semantic-ui-react'
+import { Table as SemanticTable } from '@inloco/semantic-ui-react'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 import { HorizontalAlignValues } from '../constants'
+import { createShorthandFactory } from '../../utils/factories'
 
 const ALIGN_TO_JUSTIFY_CONTENT = {
   [HorizontalAlignValues.LEFT]: 'justify-start',
@@ -26,13 +27,13 @@ const TableCell = ({
   })
   const childContent = content || children
   return (
-    <Table.Cell
+    <SemanticTable.Cell
       title={_.isString(childContent) ? childContent : null}
       {...otherProps}>
       <div className={classes}>
         <div className="inner-cell-wrapper">{childContent}</div>
       </div>
-    </Table.Cell>
+    </SemanticTable.Cell>
   )
 }
 
@@ -43,5 +44,12 @@ TableCell.propTypes = {
   highlight: PropTypes.bool,
   horizontalAlign: PropTypes.oneOf(_.values(HorizontalAlignValues))
 }
+
+// Overriding original factory. See src/utils/factories.js for more details.
+SemanticTable.Cell.create = createShorthandFactory(TableCell, content => ({
+  content
+}))
+
+TableCell.create = SemanticTable.Cell.create
 
 export default TableCell


### PR DESCRIPTION
O semantic ui tem essas factories em alguns componentes, que são bastante úteis pra criar props de shorthands e também são usadas internamente pelo próprio semantic. É importante que todo componente que a gente sobrescrever e tiver factories no semantic continue tendo também.

Notei que alguns estavam faltando (ou sobrescrever ou referenciar), então corrigi isso aqui.