### PR TITLE
fix(card): Make the card content fill any extra available space instead of the footer

### DIFF
--- a/packages/orion/src/Card/card.css
+++ b/packages/orion/src/Card/card.css
@@ -1,5 +1,6 @@
 .orion.card {
   @apply relative bg-white border-1 border-gray-900-16 inline-block rounded;
+  @apply inline-flex flex-col;
 }
 
 .orion.card.fluid {
@@ -11,11 +12,11 @@
 }
 
 .orion.card > .content {
-  @apply p-24;
+  @apply flex-grow p-24;
 }
 
 .orion.card > .extra {
-  @apply flex items-center justify-end px-24 py-8;
+  @apply flex flex-grow-0 flex-shrink-0 items-center justify-end px-24 py-8;
   @apply border-t-1 border-gray-900-16;
 }
 


### PR DESCRIPTION
Para cards que não têm height auto, caso sobre height ele estava sendo acrescentado depois do footer. Ajeitei pra esse espaço extra ir todo para o conteúdo principal.

**Antes**
<img width="353" alt="Screen Shot 2019-09-06 at 12 19 17 PM" src="https://user-images.githubusercontent.com/5216049/64439738-0d1fa300-d0a1-11e9-8dab-490155f4768f.png">

**Depois**
<img width="347" alt="Screen Shot 2019-09-06 at 12 21 09 PM" src="https://user-images.githubusercontent.com/5216049/64439739-0d1fa300-d0a1-11e9-9f1d-be347529e2c6.png">
