### PR TITLE
feature(popup): Limit the popup's width

### DIFF
--- a/packages/orion/src/Popup/popup.css
+++ b/packages/orion/src/Popup/popup.css
@@ -1,5 +1,5 @@
 .orion.popup {
-  @apply bg-white border border-gray-900-8 leading-14 p-16 rounded shadow-300 text-gray-800 z-50;
+  @apply bg-white border border-gray-900-8 leading-14 max-w-384 p-16 rounded shadow-300 text-gray-800 z-50;
 }
 
 .orion.popup:before {


### PR DESCRIPTION
Como não definimos nenhum `width` ou `max-width` para a nossa `Popup`, ela cresce com o conteúdo. Com um conteúdo muito longo isso atrapalha o hover, pois ela fica grande demais e por cima do trigger.

Notei que o semantic tinha um `max-width` na popup, e nos nossos exemplos no Invision também existia um limite. Então achei uma boa acrescentar um limite padrão logo aqui.

**Antes**
![2019-09-09 10 28 25](https://user-images.githubusercontent.com/5216049/64534956-d50ca000-d2ec-11e9-9e09-ca5e7941842d.gif)

**Depois**
![2019-09-09 10 31 16](https://user-images.githubusercontent.com/5216049/64535065-fcfc0380-d2ec-11e9-9d2b-049a89298825.gif)

