### PR TITLE
fix(table): Fix alignment of sorting arrow

### DIFF
--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -87,8 +87,12 @@
   @apply text-gray-900;
 }
 
+.orion.table.sortable th.sorted > .inner-cell {
+  @apply mr-16;
+}
+
 .orion.table.sortable th.sorted > .inner-cell::after {
-  @apply absolute ml-4 text-gray-700 text-lg transition-default font-icons;
+  @apply absolute text-gray-700 text-lg transition-default font-icons;
   content: 'keyboard_arrow_up';
   transition-property: transform;
 }


### PR DESCRIPTION
O alinhamento da setinha pra ordenação estava errado. Não notei porque fica ok com o alinhamento padrão à esquerda, mas ficava visível ao centralizar ou alinhar à direita.

**Antes**
<img width="633" alt="Screen Shot 2019-09-09 at 11 40 28 AM" src="https://user-images.githubusercontent.com/5216049/64540920-5c5f1100-d2f7-11e9-9f37-5f08063fd77b.png">

**Depois**
<img width="620" alt="Screen Shot 2019-09-09 at 11 42 25 AM" src="https://user-images.githubusercontent.com/5216049/64540921-5c5f1100-d2f7-11e9-8541-1fad279a7439.png">
