### PR TITLE
fix(filter): Fix behavior of the "Clear" filter button

### DIFF
--- a/packages/orion/src/Filter/Filter.test.js
+++ b/packages/orion/src/Filter/Filter.test.js
@@ -218,8 +218,8 @@ describe("when the filter's value changes", () => {
       expect(onClear).toHaveBeenCalled()
     })
 
-    it('should call "onChange" with the initial value', () => {
-      expect(onChange).toHaveBeenCalledWith(undefined)
+    it('should call "onChange" with the "null"', () => {
+      expect(onChange).toHaveBeenCalledWith(null)
     })
   })
 })

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -31,8 +31,6 @@ const Filter = ({
   const [localValue, setLocalValue] = useState(value)
 
   const isSelected = !_.isEmpty(value)
-  const isPristine =
-    (_.isEmpty(value) && _.isEmpty(localValue)) || _.isEqual(value, localValue)
 
   const handleApply = event => {
     setValue(localValue)
@@ -46,8 +44,8 @@ const Filter = ({
   }
 
   const handleClear = () => {
-    setLocalValue(value)
-    onChange && onChange(value)
+    setLocalValue(null)
+    onChange && onChange(null)
     onClear && onClear()
   }
 
@@ -98,7 +96,7 @@ const Filter = ({
           {children({ onChange: handleChange, value: localValue })}
         </div>
         <div className="filter-buttons">
-          <div className={cx({ invisible: isPristine })}>
+          <div className={cx({ invisible: _.isEmpty(localValue) })}>
             {Button.create(clearButton, {
               autoGenerateKey: false,
               defaultProps: {


### PR DESCRIPTION
Eu implementei o botão `Clear` como se fosse um `Cancel`, sempre restaurando o valor para o último valor aplicado. Bruno me explicou que na verdade era pra esse botão realmente dar um clear geral na seleção, deixando-a vazia, e não restaurando a última. Agora está corrigido.