### PR TITLE
feature(Wizard): add a bottom margin to the StepsNav

### DIFF
--- a/packages/orion/src/Wizard/wizard.css
+++ b/packages/orion/src/Wizard/wizard.css
@@ -1,5 +1,5 @@
 .orion.wizard .steps-nav {
-  @apply justify-center;
+  @apply justify-center mb-40;
 }
 
 .orion.wizard .wizard-controls {


### PR DESCRIPTION
O StepsNav tinha ficado sem o margin-bottom de 40px.

![Screen Shot 2019-09-19 at 18 16 09](https://user-images.githubusercontent.com/28961613/65281753-b0dd6a00-db09-11e9-832a-ddb15bc90d69.png)
