### PR TITLE
Feature/fullscreen content max width

### DIFF
--- a/packages/orion/base.css
+++ b/packages/orion/base.css
@@ -3,3 +3,8 @@
   transition-timing-function: cubic-bezier(0.64, 0, 0.35, 1);
   transition-property: all;
 }
+
+.layout-content {
+  @apply mx-24 w-full;
+  max-width: 1024px;
+}

--- a/packages/orion/src/FullscreenContainer/FullscreenContainer.stories.js
+++ b/packages/orion/src/FullscreenContainer/FullscreenContainer.stories.js
@@ -11,7 +11,7 @@ storiesOf('FullscreenContainer', module)
       <FullscreenContainer
         title={text('Title', 'My Title')}
         trigger={<Button>Open Container</Button>}>
-        <div>{text('Content', 'My Content!')}</div>
+        <div className="text-center">{text('Content', 'My Content!')}</div>
       </FullscreenContainer>
     )
   })

--- a/packages/orion/src/FullscreenContainer/fullscreenContainer.css
+++ b/packages/orion/src/FullscreenContainer/fullscreenContainer.css
@@ -7,7 +7,7 @@
 }
 
 .orion.fullscreen-container .fullscreen-container-content {
-  @apply mx-24 w-full flex flex-col items-center;
+  @apply mx-24 w-full;
   max-width: 1024px;
 }
 

--- a/packages/orion/src/FullscreenContainer/fullscreenContainer.css
+++ b/packages/orion/src/FullscreenContainer/fullscreenContainer.css
@@ -6,6 +6,11 @@
   @apply font-display text-lg mb-24 text-gray-800;
 }
 
+.orion.fullscreen-container .fullscreen-container-content {
+  @apply mx-24 w-full flex flex-col items-center;
+  max-width: 1024px;
+}
+
 .orion.fullscreen-container > .button {
   @apply cursor-pointer absolute top-0 right-0 m-8;
 }

--- a/packages/orion/src/FullscreenContainer/fullscreenContainer.css
+++ b/packages/orion/src/FullscreenContainer/fullscreenContainer.css
@@ -7,8 +7,7 @@
 }
 
 .orion.fullscreen-container .fullscreen-container-content {
-  @apply mx-24 w-full;
-  max-width: 1024px;
+  @apply layout-content;
 }
 
 .orion.fullscreen-container > .button {

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -7,8 +7,7 @@
 }
 
 .orion.layout .layout-center-content {
-  @apply mx-24 w-full;
-  max-width: 1024px;
+  @apply layout-content;
 }
 
 .orion.layout .layout-topbar {


### PR DESCRIPTION
Esse PR adiciona propriedades ao css do content de um `FullscreenContainer`. O container não estava limitando o tamanho do conteúdo, então ele podia tomar a tela inteira.

![Screen Shot 2019-09-20 at 17 57 01](https://user-images.githubusercontent.com/28961613/65453036-c1972400-de18-11e9-95b2-5e6790aea16c.png)

Fiz essa modificação para que ele siga a mesma regra do `.layout-center-content`. Outra opção seria fazer com que o content desse componente usasse a classe do layout. 

Após a modificação, a tela anterior ficaria dessa maneira:

![Screen Shot 2019-09-20 at 17 57 59](https://user-images.githubusercontent.com/28961613/65453169-06bb5600-de19-11e9-99b0-2f1d8ad61b71.png)

Uma dúvida que fiquei: a classe deveria ter properties de flex? Pergunto isso porque a mudança meio que obriga que o conteúdo sempre tenha esse tamanho do 1024. Por exemplo, a tela abaixo antes tinha comprimento menor e ficaria assim:

![Screen Shot 2019-09-23 at 15 39 47](https://user-images.githubusercontent.com/28961613/65453251-323e4080-de19-11e9-8c07-27c9a5c86fad.png)

Com properties de flex como ` flex flex-col items-center` nesse `.fullscreen-container-content`, ele voltaria ao tamanho anterior:
![Screen Shot 2019-09-23 at 15 40 01](https://user-images.githubusercontent.com/28961613/65453306-4eda7880-de19-11e9-8b0a-c31e21a8d11d.png)

