### PR TITLE
fix(button-ghost): Set bg transparent rather than white

### DIFF
--- a/packages/orion/src/Button/button.css
+++ b/packages/orion/src/Button/button.css
@@ -159,7 +159,7 @@
 /* Ghost */
 
 .orion.button.ghost {
-  @apply bg-white text-wave-500 border border-wave-500;
+  @apply bg-transparent text-wave-500 border border-wave-500;
 }
 
 .orion.button.ghost svg.icon {


### PR DESCRIPTION
Falei com Bruno e Victor, e eles disseram que este botão ghost deveria ter background `transparent` em vez de `white`.

Antes:
![image](https://user-images.githubusercontent.com/1139664/65997393-ad35d580-e46f-11e9-8e52-7f85645463b9.png)

Depois:
![image](https://user-images.githubusercontent.com/1139664/65997434-bd4db500-e46f-11e9-8e43-9cc4c0c11eb6.png)
