### PR TITLE
Feature: support for direction prop on Dropdown

### DIFF
--- a/packages/orion/src/Dropdown/Dropdown.stories.js
+++ b/packages/orion/src/Dropdown/Dropdown.stories.js
@@ -3,6 +3,7 @@ import { boolean, object, text, withKnobs } from '@storybook/addon-knobs'
 
 import Dropdown from './'
 import { Sizes } from '../utils/sizes'
+import { Directions } from '../utils/directions'
 import { sizeKnob } from '../utils/stories'
 
 const developerOptions = [
@@ -25,6 +26,27 @@ export const basic = () => {
       compact={boolean('Compact', true)}
       size={sizeKnob('small')}
     />
+  )
+}
+
+export const direction = () => {
+  return (
+    <div className="flex justify-between" style={{ width: '300px' }}>
+      <Dropdown
+        text={text('Left Label', 'Left menu')}
+        options={object('Menu options', developerOptions)}
+        compact={boolean('Compact', true)}
+        size={sizeKnob('small')}
+        direction={Directions.LEFT}
+      />
+      <Dropdown
+        text={text('Right Label', 'Right menu')}
+        options={object('Menu options', developerOptions)}
+        compact={boolean('Compact', true)}
+        size={sizeKnob('small')}
+        direction={Directions.RIGHT}
+      />
+    </div>
   )
 }
 

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -39,6 +39,10 @@
   top: 100%;
 }
 
+.orion.dropdown > .right {
+  @apply right-0 left-auto;
+}
+
 .orion.dropdown.active > .menu {
   @apply block rounded;
 }

--- a/packages/orion/src/Dropdown/index.js
+++ b/packages/orion/src/Dropdown/index.js
@@ -6,6 +6,7 @@ import { Dropdown as SemanticDropdown } from '@inloco/semantic-ui-react'
 
 import Divider from '../Divider'
 import { Sizes, sizePropType } from '../utils/sizes'
+import { Directions, directionPropType } from '../utils/directions'
 import DropdownItem from './DropdownItem'
 import DropdownKeepSelected from './DropdownKeepSelected'
 import useInlineMenuWrapper from './useInlineMenuWrapper'
@@ -72,13 +73,15 @@ Dropdown.propTypes = {
     PropTypes.oneOf(_.values(MultipleModes))
   ]),
   size: sizePropType,
+  direction: directionPropType,
   warning: PropTypes.bool
 }
 
 Dropdown.defaultProps = {
   deburr: true,
   icon: DROPDOWN_ICON,
-  size: Sizes.DEFAULT
+  size: Sizes.DEFAULT,
+  direction: Directions.LEFT
 }
 
 Dropdown.Divider = Divider

--- a/packages/orion/src/utils/directions.js
+++ b/packages/orion/src/utils/directions.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types'
+
+export const Directions = {
+  LEFT: 'left',
+  RIGHT: 'right'
+}
+
+export const directionPropType = PropTypes.oneOf([
+  Directions.LEFT,
+  Directions.RIGHT
+])


### PR DESCRIPTION
Solves https://github.com/inloco/orion/issues/256.

This adds the style needed to set the `direction` prop as `left|right`. By default, Semantic UI sets the direction to be left, so the respective style is not needed.

![direction](https://user-images.githubusercontent.com/15937541/66438859-4df23b00-ea04-11e9-9c11-f4d5f00efc2f.gif)
 