### PR TITLE
feature(tailwind.config): add the first and last variants to margin

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -421,7 +421,7 @@ module.exports = {
     lineHeight: ['responsive'],
     listStylePosition: ['responsive'],
     listStyleType: ['responsive'],
-    margin: ['responsive'],
+    margin: ['responsive', 'first', 'last'],
     maxHeight: ['responsive'],
     maxWidth: ['responsive'],
     minHeight: ['responsive'],


### PR DESCRIPTION
Adds the `first` and `last` variants to margins. These variants work as `first-child` and `last-child`.

The main use case will be to add margins to a list of components, minus the first/last one.