### PR TITLE
Refactor: eslint fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Orion Monorepo
 
+![npm](https://img.shields.io/npm/v/@inloco/orion?color=green&label=%40inloco%2Forion)
+![npm](https://img.shields.io/npm/v/@inloco/atomic-bomb?color=green&label=%40inloco%2Fatomic-bomb)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=inloco/orion)](https://dependabot.com)
 
 In Loco's monorepo for [Orion](https://github.com/inloco/orion/tree/master/packages/orion) and [Atomic Bomb](https://github.com/inloco/orion/tree/master/packages/atomic-bomb).

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "pretty-quick --staged",
+      "pre-push": "yarn orion:lint --fix"
     }
   },
   "scripts": {

--- a/packages/orion/src/ClickOutside/index.js
+++ b/packages/orion/src/ClickOutside/index.js
@@ -15,7 +15,7 @@ const ClickOutside = ({ as, children, onClickOutside, ...otherProps }) => {
     return () => {
       document.removeEventListener('mouseup', handleClick, true)
     }
-  }, [onClickOutside])
+  }, [handleClick, onClickOutside])
 
   const ElementType = as
   return (

--- a/packages/orion/src/Dropdown/index.js
+++ b/packages/orion/src/Dropdown/index.js
@@ -91,6 +91,6 @@ Dropdown.Menu = SemanticDropdown.Menu
 Dropdown.SearchInput = SemanticDropdown.SearchInput
 
 Dropdown.ICON = DROPDOWN_ICON
-Dropdown.MultipleModes
+Dropdown.MultipleModes = MultipleModes
 
 export default Dropdown

--- a/packages/orion/src/Filter/Filter.stories.js
+++ b/packages/orion/src/Filter/Filter.stories.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
 import { object, text, withKnobs } from '@storybook/addon-knobs'
+import PropTypes from 'prop-types'
+import _ from 'lodash'
 
 import { Dropdown, Filter, Input } from '../'
 
@@ -81,3 +83,8 @@ const FilterStoryInput = ({ onChange, value, ...otherProps }) => (
     {...otherProps}
   />
 )
+
+FilterStoryInput.propTypes = {
+  onChange: PropTypes.func,
+  value: PropTypes.oneOf([PropTypes.string, PropTypes.number])
+}

--- a/packages/orion/src/RangedDatepicker/index.js
+++ b/packages/orion/src/RangedDatepicker/index.js
@@ -25,7 +25,7 @@ const RangedDatepicker = ({
   const focusedInput = focusedInputProp || focusedInputState
   const handleFocusChange = newFocusedInput => {
     setFocusedInput(newFocusedInput)
-    onFocusChange && onFocusChange(newDates)
+    onFocusChange && onFocusChange(newFocusedInput)
   }
 
   return (
@@ -51,7 +51,10 @@ RangedDatepicker.propTypes = {
   defaultDates: PropTypes.shape({
     startDate: PropTypes.any,
     endDate: PropTypes.any
-  })
+  }),
+  focusedInput: PropTypes.node,
+  onDatesChange: PropTypes.func,
+  onFocusChange: PropTypes.func
 }
 
 export default RangedDatepicker


### PR DESCRIPTION
## Changes

- [x] add version badges to docs
- [x] fix linted errors
- [x] add husky pre-push lint fix hook

Docs com versões fica bonitinho:
![image](https://user-images.githubusercontent.com/3356720/67157581-bb458a80-f379-11e9-9bdd-2eb66c34f16b.png)

Corrigi os erros e os warnings abaixo dos mesmos arquivos. Ainda tem 51 warnings sobre falta de `propTypes`.
```bash
orion/packages/orion/src/RangedDatepicker/index.js
  12:3   warning  'focusedInput' is missing in props validation   react/prop-types
  13:3   warning  'onDatesChange' is missing in props validation  react/prop-types
  14:3   warning  'onFocusChange' is missing in props validation  react/prop-types
  28:36  error    'newDates' is not defined

orion/packages/orion/src/Dropdown/index.js
  94:1  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions

orion/src/Filter/Filter.stories.js
  51:24  error    '_' is not defined                         no-undef
  75:29  warning  'onChange' is missing in props validation  react/prop-types
  75:39  warning  'value' is missing in props validation     react/prop-types
```

