### PR TITLE
feature(Loading): disable the animation pause on click

### DIFF
--- a/packages/orion/src/Loading/index.js
+++ b/packages/orion/src/Loading/index.js
@@ -13,6 +13,7 @@ const Loading = ({ className, inline, size, ...otherProps }) => {
   return (
     <div className={classes} {...otherProps}>
       <Lottie
+        isClickToPauseDisabled
         options={{
           loop: true,
           autoplay: true,


### PR DESCRIPTION
A animação de loading parava se o componente fosse clicado.

![2019-10-25 12 08 25](https://user-images.githubusercontent.com/28961613/67582697-97d76280-f720-11e9-8fe9-542d1d5f7e95.gif)

Essa prop desabilita esse pause (https://github.com/chenqingspring/react-lottie/issues/81). 
