### PR TITLE
Feature/search fixes

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -240,6 +240,7 @@ module.exports = {
     height: theme => ({
       auto: 'auto',
       ...theme('spacing'),
+      em: '1em',
       full: '100%',
       screen: '100vh'
     }),
@@ -374,6 +375,7 @@ module.exports = {
       '9/12': '75%',
       '10/12': '83.33333%',
       '11/12': '91.66667%',
+      em: '1em',
       full: '100%',
       screen: '100vw'
     }),

--- a/packages/orion/src/Dropdown/Dropdown.stories.js
+++ b/packages/orion/src/Dropdown/Dropdown.stories.js
@@ -99,7 +99,9 @@ export const detailedItems = () => (
       placeholder="Select Developer"
       selection
       search
+      loading={boolean('Loading', false)}
       multiple="keep"
+      size={sizeKnob()}
       fluid>
       <Dropdown.Menu>
         <Dropdown.Item text="Strawberry" description="Red" value="1" />

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -68,7 +68,7 @@
  */
 
 .orion.dropdown.search {
-  @apply inline-flex cursor-text border-solid;
+  @apply inline-flex cursor-text;
 }
 
 .orion.dropdown.search input {

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -68,7 +68,7 @@
  */
 
 .orion.dropdown.search {
-  @apply inline-flex cursor-text;
+  @apply inline-flex cursor-text border-solid;
 }
 
 .orion.dropdown.search input {
@@ -151,7 +151,7 @@
  */
 
 .orion.dropdown.selection {
-  @apply bg-white border border-gray-900-24 px-16 rounded;
+  @apply bg-white border border-solid border-gray-900-24 px-16 rounded;
 }
 
 .orion.dropdown.selection.small {

--- a/packages/orion/src/Dropdown/index.js
+++ b/packages/orion/src/Dropdown/index.js
@@ -16,9 +16,7 @@ const DROPDOWN_ICON = {
   name: 'keyboard_arrow_down'
 }
 
-const LOADING_ICON = {
-  name: 'loading'
-}
+const LOADING_ICON = 'loading'
 
 const MultipleModes = {
   FILTER_SELECTED: true,

--- a/packages/orion/src/Input/input.css
+++ b/packages/orion/src/Input/input.css
@@ -6,7 +6,7 @@
 }
 
 .orion.input:not(.labeled) > input {
-  @apply bg-white border border-gray-900-24 rounded;
+  @apply bg-white border border-solid border-gray-900-24 rounded;
 }
 
 .orion.input > input:disabled {
@@ -20,6 +20,11 @@
 .orion.input > input:active,
 .orion.input > input:focus {
   @apply shadow-field-active;
+}
+
+.orion.input > .loading.icon:before,
+.orion.input > .loading.icon:after {
+  @apply h-em w-em;
 }
 
 .orion.input.small > input {

--- a/packages/orion/src/Search/Search.stories.js
+++ b/packages/orion/src/Search/Search.stories.js
@@ -1,11 +1,5 @@
 import React from 'react'
-import {
-  boolean,
-  object,
-  radios,
-  text,
-  withKnobs
-} from '@storybook/addon-knobs'
+import { boolean, object, text, withKnobs } from '@storybook/addon-knobs'
 
 import { Search } from '../'
 import { sizeKnob } from '../utils/stories'
@@ -30,6 +24,7 @@ export const basic = () => {
       disabled={boolean('Disabled', false)}
       error={boolean('Error', false)}
       warning={boolean('Warning', false)}
+      loading={boolean('Loading', false)}
     />
   )
 }

--- a/packages/orion/src/Search/index.js
+++ b/packages/orion/src/Search/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Search as SemanticSearch } from '@inloco/semantic-ui-react'
+
+const LOADING_ICON = {
+  name: 'loading'
+}
+
+const Search = ({ loading, icon, ...otherProps }) => {
+  const searchProps = {
+    icon: loading ? LOADING_ICON : icon,
+    ...otherProps
+  }
+
+  return <SemanticSearch {...searchProps} />
+}
+
+Search.Category = SemanticSearch.Category
+Search.Result = SemanticSearch.Result
+Search.Results = SemanticSearch.Results
+
+export default Search

--- a/packages/orion/src/Search/index.js
+++ b/packages/orion/src/Search/index.js
@@ -2,9 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Search as SemanticSearch } from '@inloco/semantic-ui-react'
 
-const LOADING_ICON = {
-  name: 'loading'
-}
+const LOADING_ICON = 'loading'
 
 const Search = ({ loading, icon, ...otherProps }) => {
   return <SemanticSearch {...otherProps} icon={loading ? LOADING_ICON : icon} />

--- a/packages/orion/src/Search/index.js
+++ b/packages/orion/src/Search/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Search as SemanticSearch } from '@inloco/semantic-ui-react'
 
 const LOADING_ICON = {
@@ -7,6 +8,11 @@ const LOADING_ICON = {
 
 const Search = ({ loading, icon, ...otherProps }) => {
   return <SemanticSearch {...otherProps} icon={loading ? LOADING_ICON : icon} />
+}
+
+Search.propTypes = {
+  loading: PropTypes.bool,
+  icon: PropTypes.any
 }
 
 Search.Category = SemanticSearch.Category

--- a/packages/orion/src/Search/index.js
+++ b/packages/orion/src/Search/index.js
@@ -6,12 +6,7 @@ const LOADING_ICON = {
 }
 
 const Search = ({ loading, icon, ...otherProps }) => {
-  const searchProps = {
-    icon: loading ? LOADING_ICON : icon,
-    ...otherProps
-  }
-
-  return <SemanticSearch {...searchProps} />
+  return <SemanticSearch {...otherProps} icon={loading ? LOADING_ICON : icon} />
 }
 
 Search.Category = SemanticSearch.Category

--- a/packages/orion/src/Search/search.css
+++ b/packages/orion/src/Search/search.css
@@ -6,6 +6,11 @@
   @apply h-32;
 }
 
+.orion.search > .orion.input > .loading.icon:before,
+.orion.search > .orion.input > .loading.icon:after {
+  @apply h-em w-em;
+}
+
 .orion.search > .orion.input {
   @apply h-full;
 }

--- a/packages/orion/src/Search/search.css
+++ b/packages/orion/src/Search/search.css
@@ -15,12 +15,16 @@
 }
 
 .orion.search .results {
-  @apply absolute hidden mt-8 shadow-200 left-0 w-full;
+  @apply absolute bg-white hidden mt-8 shadow-200 left-0 w-full;
   top: 100%;
 }
 
 .orion.search.active .results {
   @apply block rounded;
+}
+
+.orion.search.active .results > .message.empty {
+  @apply px-16 py-8;
 }
 
 .orion.search .results > .result {

--- a/packages/orion/src/Search/search.css
+++ b/packages/orion/src/Search/search.css
@@ -6,17 +6,12 @@
   @apply h-32;
 }
 
-.orion.search > .orion.input > .loading.icon:before,
-.orion.search > .orion.input > .loading.icon:after {
-  @apply h-em w-em;
-}
-
 .orion.search > .orion.input {
   @apply h-full;
 }
 
 .orion.search > .orion.input > input {
-  @apply h-full border-solid !important;
+  @apply h-full !important;
 }
 
 .orion.search .results {

--- a/packages/orion/src/Search/search.css
+++ b/packages/orion/src/Search/search.css
@@ -16,7 +16,7 @@
 }
 
 .orion.search > .orion.input > input {
-  @apply h-full !important;
+  @apply h-full border-solid !important;
 }
 
 .orion.search .results {

--- a/packages/orion/src/index.js
+++ b/packages/orion/src/index.js
@@ -4,7 +4,6 @@ export {
   Modal,
   Popup,
   Portal,
-  Search,
   Select
 } from '@inloco/semantic-ui-react'
 
@@ -30,6 +29,7 @@ export { default as NotificationCenter } from './NotificationCenter'
 export { default as Progress } from './Progress'
 export { default as RangedDatepicker } from './RangedDatepicker'
 export { default as StepsNav } from './StepsNav'
+export { default as Search } from './Search'
 export { default as Table } from './Table'
 export { default as Tooltip } from './Tooltip'
 export { default as Wizard } from './Wizard'


### PR DESCRIPTION
Corrigindo três problemas com o componente `Search`
* O menu de resultados estava com o background transparente.
* O item de "No results" estava sem o padding correto.
* A prop 'loading' não estava funcionando, pois pra o Search o ícone muda com o seletor da classe .loading, que não está carregado. Resolvi mudando o ícone manualmente de acordo com a prop, da mesma forma que é feito no Dropdown. Mas como a montagem do search é um pouco diferente do dropdown, o loading com o height e width 100% ficaria com o ícone do tamanho da caixa inteira. Precisei adicionar mais uma regra no tailwind pra usar o height e width do tamanho da fonte.

Antes:
![orion-search-before](https://user-images.githubusercontent.com/9112403/67694327-edf71080-f981-11e9-8ae0-5e4b1f2eede1.gif)

Depois:
![orion-search-after](https://user-images.githubusercontent.com/9112403/67694333-f0f20100-f981-11e9-867b-ddc5d5602e07.gif)

Acho que esse é meu primeiro PR no projeto, então me digam se fiz algo errado ou faltou fazer algo, please. 😅 