### PR TITLE
feature(base.css): update the default transition duration to 0.15s

### DIFF
--- a/packages/orion/base.css
+++ b/packages/orion/base.css
@@ -1,5 +1,5 @@
 .transition-default {
-  transition-duration: 0.2s;
+  transition-duration: 0.15s;
   transition-timing-function: cubic-bezier(0.64, 0, 0.35, 1);
   transition-property: all;
 }


### PR DESCRIPTION
Na avaliação que Bruno fez do application, ele pediu que as animações em geral tivessem um tempo de 0.15s ao invés de 0.2s, já que achava que tava um pouco lento.

![Screen Shot 2019-10-28 at 10 38 47](https://user-images.githubusercontent.com/28961613/67721592-b1450c80-f9b5-11e9-8083-4ae775c35fdf.png)
