### PR TITLE
Feature/modal z index

### DIFF
--- a/packages/orion/src/FullscreenContainer/index.js
+++ b/packages/orion/src/FullscreenContainer/index.js
@@ -32,7 +32,9 @@ const FullscreenContainer = ({
       trigger={trigger}
       open={open}
       onOpen={handleOpen}
-      onClose={handleClose}>
+      onClose={handleClose}
+      closeOnDocumentClick={false}
+      closeOnEscape={false}>
       <div className={cx('orion fullscreen-container', className)}>
         <Button subtle icon="close" onClick={handleClose} />
         {title && <div className="fullscreen-container-title">{title}</div>}

--- a/packages/orion/src/Modal/modal.css
+++ b/packages/orion/src/Modal/modal.css
@@ -3,11 +3,19 @@
 *******************************/
 
 .orion.modal {
-  @apply absolute hidden z-10 text-left bg-white border-0 rounded flex shadow-200 select-text;
+  @apply absolute hidden z-50 text-left bg-white border-0 rounded flex shadow-200 select-text;
   min-width: 492px;
   left: 50%;
   top: 24px;
   transform: translate(-50%, 0);
+}
+
+/*--------------
+     Dimmer
+---------------*/
+
+.orion.modals.dimmer {
+  @apply z-50;
 }
 
 /*******************************


### PR DESCRIPTION
Fui tentar usar um modal dentro do `FullscreenContainer` e vi dois problemas:

1. O z-index do modal e do dimmer eram menores do que o do FullscreenContainer, e o modal ficava por baixo.

2. Um click no modal fechava o FullscreenContainer (e consequentemente o modal).

Esse pr corrige essas duas issues pra poder usar o modal.

![2019-11-07 15 02 53](https://user-images.githubusercontent.com/28961613/68414865-c49f6700-016f-11ea-89d2-c1b8bf10c52f.gif)
