### PR TITLE
feature(Message): change the icon padding to 16

### DIFF
--- a/packages/orion/src/Message/message.css
+++ b/packages/orion/src/Message/message.css
@@ -14,11 +14,7 @@
   @apply border-yellow-500 bg-yellow-50;
 }
 
-.orion.message > .icon:not(.close) {
-  @apply pr-4;
-}
-
-.orion.message.header > .icon {
+.orion.message > .icon {
   @apply pr-16;
 }
 


### PR DESCRIPTION
O `padding-right` de 4px quando não tinha título deixava o texto bem próximo do ícone.

Esse PR altera o `padding-right` para que a distância do ícone seja igual ao padding do `Message`.

Antes:
![Screen Shot 2019-11-08 at 14 31 36](https://user-images.githubusercontent.com/28961613/68498959-de57b180-0236-11ea-9dfc-f679a22ae7fc.png)
![Screen Shot 2019-11-08 at 14 42 21](https://user-images.githubusercontent.com/28961613/68498965-e152a200-0236-11ea-9609-f5377f2a5c00.png)

Depois:
![Screen Shot 2019-11-08 at 14 42 30](https://user-images.githubusercontent.com/28961613/68498997-ea437380-0236-11ea-8d11-4f96856dca4e.png)

