### PR TITLE
feature(StepsNav): add text-center

### DIFF
--- a/packages/orion/src/StepsNav/stepsNav.css
+++ b/packages/orion/src/StepsNav/stepsNav.css
@@ -43,7 +43,7 @@
 }
 
 .orion.steps-nav .steps-nav-step-name {
-  @apply mt-4;
+  @apply mt-4 text-center;
 }
 
 /*--------------


### PR DESCRIPTION
O texto estava alinhado à esquerda, o que era um problema quando tinha quebra de linha. 

Antes
![Screen Shot 2019-11-08 at 15 09 11](https://user-images.githubusercontent.com/28961613/68500262-0399ef00-023a-11ea-8c11-dc0d8480d75d.png)

Depois
![Screen Shot 2019-11-08 at 15 09 45](https://user-images.githubusercontent.com/28961613/68500274-08f73980-023a-11ea-9ebc-33070c4c69e3.png)
