### PR TITLE
chore(negative-margin): Remove negative margin

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -270,10 +270,9 @@ module.exports = {
       disc: 'disc',
       decimal: 'decimal'
     },
-    margin: (theme, { negative }) => ({
+    margin: theme => ({
       auto: 'auto',
-      ...theme('spacing'),
-      ...negative(theme('spacing'))
+      ...theme('spacing')
     }),
     maxHeight: {
       full: '100%',


### PR DESCRIPTION
Removendo a margem negativa, conseguimos diminuir o bundle de 38kb para 34kb (gziped) do Atomic bomb.