### PR TITLE
Refactor: export types as an attribute of StatusTag

### DIFF
--- a/packages/orion/src/StatusTag/StatusTag.stories.js
+++ b/packages/orion/src/StatusTag/StatusTag.stories.js
@@ -4,7 +4,6 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 import { sizeKnob } from '../utils/stories'
 import { Sizes } from '../utils/sizes'
 import { StatusTag } from '..'
-import { types } from './'
 
 export default {
   title: 'StatusTag',
@@ -21,7 +20,7 @@ export const cancelled = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={types.CANCELLED}>
+      type={StatusTag.Types.CANCELLED}>
       {text('Label', 'Cancelled')}
     </StatusTag>
   )
@@ -37,7 +36,7 @@ export const waiting = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={types.WAITING}>
+      type={StatusTag.Types.WAITING}>
       {text('Label', 'Waiting')}
     </StatusTag>
   )
@@ -53,7 +52,7 @@ export const pending = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={types.PENDING}>
+      type={StatusTag.Types.PENDING}>
       {text('Label', 'Pending')}
     </StatusTag>
   )
@@ -69,7 +68,7 @@ export const error = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={types.ERROR}>
+      type={StatusTag.Types.ERROR}>
       {text('Label', 'Error')}
     </StatusTag>
   )
@@ -85,7 +84,7 @@ export const running = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={types.RUNNING}>
+      type={StatusTag.Types.RUNNING}>
       {text('Label', 'Running')}
     </StatusTag>
   )

--- a/packages/orion/src/StatusTag/index.js
+++ b/packages/orion/src/StatusTag/index.js
@@ -5,7 +5,7 @@ import { Label } from '@inloco/semantic-ui-react'
 
 import { Sizes, sizePropType } from '../utils/sizes'
 
-export const types = {
+const Types = {
   CANCELLED: 'cancelled',
   WAITING: 'waiting',
   PENDING: 'pending',
@@ -19,6 +19,8 @@ const StatusTag = ({ className, type, size, filled, bordered, children }) => {
   return <Label className={classes}>{children}</Label>
 }
 
+StatusTag.Types = Types
+
 StatusTag.defaultProps = {
   size: Sizes.DEFAULT,
   bordered: true,
@@ -27,7 +29,7 @@ StatusTag.defaultProps = {
 
 StatusTag.propTypes = {
   size: sizePropType,
-  type: PropTypes.oneOf(Object.values(types)),
+  type: PropTypes.oneOf(Object.values(Types)),
   bordered: PropTypes.bool,
   filled: PropTypes.bool
 }


### PR DESCRIPTION
Como @mairatma havia sugerido, configuro `Types` como um atributo de `StatusTag`. Dessa forma, o dev pode acessá-lo apenas importando `StatusTag`.