### PR TITLE
Refactor: rename StatusTag types

### DIFF
--- a/packages/orion/src/StatusTag/StatusTag.stories.js
+++ b/packages/orion/src/StatusTag/StatusTag.stories.js
@@ -10,7 +10,7 @@ export default {
   decorators: [withKnobs]
 }
 
-export const cancelled = () => {
+export const inactive = () => {
   const size = sizeKnob(Sizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
@@ -20,13 +20,13 @@ export const cancelled = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={StatusTag.Types.CANCELLED}>
+      type={StatusTag.Types.INACTIVE}>
       {text('Label', 'Cancelled')}
     </StatusTag>
   )
 }
 
-export const waiting = () => {
+export const neutral = () => {
   const size = sizeKnob(Sizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
@@ -36,13 +36,13 @@ export const waiting = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={StatusTag.Types.WAITING}>
+      type={StatusTag.Types.NEUTRAL}>
       {text('Label', 'Waiting')}
     </StatusTag>
   )
 }
 
-export const pending = () => {
+export const warning = () => {
   const size = sizeKnob(Sizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
@@ -52,7 +52,7 @@ export const pending = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={StatusTag.Types.PENDING}>
+      type={StatusTag.Types.WARNING}>
       {text('Label', 'Pending')}
     </StatusTag>
   )
@@ -74,7 +74,7 @@ export const error = () => {
   )
 }
 
-export const running = () => {
+export const success = () => {
   const size = sizeKnob(Sizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
@@ -84,7 +84,7 @@ export const running = () => {
       size={size}
       bordered={bordered}
       filled={filled}
-      type={StatusTag.Types.RUNNING}>
+      type={StatusTag.Types.SUCCESS}>
       {text('Label', 'Running')}
     </StatusTag>
   )

--- a/packages/orion/src/StatusTag/index.js
+++ b/packages/orion/src/StatusTag/index.js
@@ -6,11 +6,11 @@ import { Label } from '@inloco/semantic-ui-react'
 import { Sizes, sizePropType } from '../utils/sizes'
 
 const Types = {
-  CANCELLED: 'cancelled',
-  WAITING: 'waiting',
-  PENDING: 'pending',
+  INACTIVE: 'inactive',
+  NEUTRAL: 'neutral',
+  WARNING: 'warning',
   ERROR: 'error',
-  RUNNING: 'running'
+  SUCCESS: 'success'
 }
 
 const StatusTag = ({ className, type, size, filled, bordered, children }) => {

--- a/packages/orion/src/StatusTag/statusTag.css
+++ b/packages/orion/src/StatusTag/statusTag.css
@@ -19,15 +19,15 @@
      Cancelled
 ---------------*/
 
-.orion.status-tag.cancelled {
+.orion.status-tag.inactive {
   @apply text-gray-700;
 }
 
-.orion.status-tag.cancelled.filled {
+.orion.status-tag.inactive.filled {
   @apply bg-gray-200;
 }
 
-.orion.status-tag.cancelled.bordered {
+.orion.status-tag.inactive.bordered {
   @apply border-gray-700;
 }
 
@@ -35,15 +35,15 @@
      Waiting
 ---------------*/
 
-.orion.status-tag.waiting {
+.orion.status-tag.neutral {
   @apply text-space-600;
 }
 
-.orion.status-tag.waiting.filled {
+.orion.status-tag.neutral.filled {
   @apply bg-space-50;
 }
 
-.orion.status-tag.waiting.bordered {
+.orion.status-tag.neutral.bordered {
   @apply border-space-600;
 }
 
@@ -51,15 +51,15 @@
      Pending
 ---------------*/
 
-.orion.status-tag.pending {
+.orion.status-tag.warning {
   @apply text-yellow-600;
 }
 
-.orion.status-tag.pending.filled {
+.orion.status-tag.warning.filled {
   @apply bg-yellow-50;
 }
 
-.orion.status-tag.pending.bordered {
+.orion.status-tag.warning.bordered {
   @apply border-yellow-500;
 }
 
@@ -83,14 +83,14 @@
      Running
 ---------------*/
 
-.orion.status-tag.running {
+.orion.status-tag.success {
   @apply text-green-700;
 }
 
-.orion.status-tag.running.filled {
+.orion.status-tag.success.filled {
   @apply bg-green-50;
 }
 
-.orion.status-tag.running.bordered {
+.orion.status-tag.success.bordered {
   @apply border-green-500;
 }


### PR DESCRIPTION
Como sugerido por @marcelscr , esses nomes se encaixam mais no padrão.