### PR TITLE
feature(dropdown): Allow passing ref to "Dropdown"

### DIFF
--- a/packages/orion/src/Dropdown/index.js
+++ b/packages/orion/src/Dropdown/index.js
@@ -23,48 +23,49 @@ const MultipleModes = {
   KEEP_SELECTED: 'keep'
 }
 
-const Dropdown = ({
-  className,
-  icon,
-  inlineMenu,
-  multiple,
-  size,
-  warning,
-  ...otherProps
-}) => {
-  const { loading, options } = otherProps
-  const shouldKeepSelected = options && multiple === MultipleModes.KEEP_SELECTED
-  const classes = cx(className, size, {
-    'inline-menu': inlineMenu,
-    'keep-selected': shouldKeepSelected,
-    warning
-  })
+const Dropdown = React.forwardRef(
+  (
+    { className, icon, inlineMenu, multiple, size, warning, ...otherProps },
+    ref
+  ) => {
+    const { loading, options } = otherProps
+    const shouldKeepSelected =
+      options && multiple === MultipleModes.KEEP_SELECTED
+    const classes = cx(className, size, {
+      'inline-menu': inlineMenu,
+      'keep-selected': shouldKeepSelected,
+      warning
+    })
 
-  const dropdownProps = {
-    className: classes,
-    icon: loading ? LOADING_ICON : icon,
-    multiple: !!multiple,
-    ...otherProps
+    const dropdownProps = {
+      className: classes,
+      icon: loading ? LOADING_ICON : icon,
+      multiple: !!multiple,
+      ref,
+      ...otherProps
+    }
+
+    const ElementType = shouldKeepSelected
+      ? DropdownKeepSelected
+      : SemanticDropdown
+    const element = <ElementType {...dropdownProps} />
+
+    const [wrapperRef, wrapperMargin] = useInlineMenuWrapper(options)
+    if (inlineMenu) {
+      return (
+        <div ref={wrapperRef} style={{ marginBottom: `${wrapperMargin}px` }}>
+          {element}
+        </div>
+      )
+    }
+
+    return element
   }
-
-  const ElementType = shouldKeepSelected
-    ? DropdownKeepSelected
-    : SemanticDropdown
-  const element = <ElementType {...dropdownProps} />
-
-  const [wrapperRef, wrapperMargin] = useInlineMenuWrapper(options)
-  if (inlineMenu) {
-    return (
-      <div ref={wrapperRef} style={{ marginBottom: `${wrapperMargin}px` }}>
-        {element}
-      </div>
-    )
-  }
-
-  return element
-}
+)
 
 Dropdown.propTypes = {
+  className: PropTypes.string,
+  icon: PropTypes.any,
   inlineMenu: PropTypes.bool,
   multiple: PropTypes.oneOfType([
     PropTypes.bool,


### PR DESCRIPTION
No momento é impossível passar `ref` para **Dropdown** porque ele é um function component. O componente original do semantic ui podia receber `ref` normalmente por ser uma classe, e realmente isso é importante pois pode ser necessário acessar os elementos do dropdown (para ouvir o scroll, por exemplo).

Pra fazer isso funcionar com um function component basta usar `React.fowardRef` para poder indicar a que elemento o `ref` vai se associa. Foi apenas isso que fiz aqui.