### PR TITLE
feature(dropdown): Add prop for hiding selected labels on the multiple dropdown

### DIFF
--- a/packages/orion/src/Dropdown/Dropdown.stories.js
+++ b/packages/orion/src/Dropdown/Dropdown.stories.js
@@ -1,10 +1,15 @@
 import React from 'react'
+import { action } from '@storybook/addon-actions'
 import { boolean, object, text, withKnobs } from '@storybook/addon-knobs'
 
 import Dropdown from './'
 import { Sizes } from '../utils/sizes'
 import { Directions } from '../utils/directions'
 import { sizeKnob } from '../utils/stories'
+
+const actions = {
+  onChange: action('onChange')
+}
 
 const developerOptions = [
   { text: 'Francisco Gileno', value: 1 },
@@ -25,6 +30,7 @@ export const basic = () => {
       options={object('Menu options', menuOptions)}
       compact={boolean('Compact', true)}
       size={sizeKnob('small')}
+      {...actions}
     />
   )
 }
@@ -38,6 +44,7 @@ export const direction = () => {
         compact={boolean('Compact', true)}
         size={sizeKnob('small')}
         direction={Directions.LEFT}
+        {...actions}
       />
       <Dropdown
         text={text('Right Label', 'Right menu')}
@@ -45,6 +52,7 @@ export const direction = () => {
         compact={boolean('Compact', true)}
         size={sizeKnob('small')}
         direction={Directions.RIGHT}
+        {...actions}
       />
     </div>
   )
@@ -62,12 +70,14 @@ export const selection = () => {
       compact={boolean('Compact', false, 'Size')}
       search={boolean('Search', false, 'Type')}
       multiple={boolean('Multiple', false, 'Type')}
+      noSelectedLabels={boolean('No Selected Labels', false, 'Type')}
       inlineMenu={boolean('Inline Menu', false, 'Type')}
       size={sizeKnob(Sizes.DEFAULT, 'Size')}
       disabled={boolean('Disabled', false, 'State')}
       loading={boolean('Loading', false, 'State')}
       error={boolean('Error', false, 'State')}
       warning={boolean('Warning', false, 'State')}
+      {...actions}
     />
   )
 }
@@ -81,9 +91,11 @@ export const multipleSelectionKeepingSelected = () => {
         icon="search"
         search
         multiple="keep"
+        noSelectedLabels={boolean('No Selected Labels', false)}
         inlineMenu
         fluid
         options={object('Options', developerOptions)}
+        {...actions}
       />
     </div>
   )
@@ -102,7 +114,8 @@ export const detailedItems = () => (
       loading={boolean('Loading', false)}
       multiple="keep"
       size={sizeKnob()}
-      fluid>
+      fluid
+      {...actions}>
       <Dropdown.Menu>
         <Dropdown.Item text="Strawberry" description="Red" value="1" />
         <Dropdown.Divider />

--- a/packages/orion/src/Dropdown/Dropdown.test.js
+++ b/packages/orion/src/Dropdown/Dropdown.test.js
@@ -73,3 +73,33 @@ describe('when an option is selected', () => {
     })
   })
 })
+
+describe('when using a multiple dropdown without selected labels ', () => {
+  it('should render a special element with the given placeholder instead of a real placeholder', () => {
+    const placeholder = 'Select Color'
+    const { queryByText, queryByPlaceholderText } = render(
+      <Dropdown placeholder={placeholder} search selection options={options} />
+    )
+
+    expect(queryByText(placeholder)).toBeTruthy()
+    expect(queryByPlaceholderText(placeholder)).toBeNull()
+  })
+
+  describe('when dropdown shows no selected labels', () => {
+    it('should render the given placeholder as a real placeholder', () => {
+      const placeholder = 'Select Color'
+      const { queryByText, queryByPlaceholderText } = render(
+        <Dropdown
+          noSelectedLabels
+          placeholder={placeholder}
+          search
+          selection
+          options={options}
+        />
+      )
+
+      expect(queryByPlaceholderText(placeholder)).toBeTruthy()
+      expect(queryByText(placeholder)).toBeNull()
+    })
+  })
+})

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -98,6 +98,25 @@
 }
 
 /**
+ * Multiple + No Selected Labels
+ */
+.orion.dropdown.multiple.no-selected-labels .orion.label {
+  @apply hidden;
+}
+
+.orion.dropdown.multiple.no-selected-labels .orion.label + input {
+  @apply ml-0;
+}
+
+.orion.dropdown.multiple.no-selected-labels input {
+  @apply flex-grow;
+}
+
+.orion.dropdown.multiple.no-selected-labels input::placeholder {
+  @apply text-gray-800;
+}
+
+/**
  * Multiple + Keep selected
  */
 

--- a/packages/orion/src/Dropdown/index.js
+++ b/packages/orion/src/Dropdown/index.js
@@ -25,7 +25,17 @@ const MultipleModes = {
 
 const Dropdown = React.forwardRef(
   (
-    { className, icon, inlineMenu, multiple, size, warning, ...otherProps },
+    {
+      className,
+      icon,
+      inlineMenu,
+      multiple,
+      noSelectedLabels,
+      placeholder,
+      size,
+      warning,
+      ...otherProps
+    },
     ref
   ) => {
     const { loading, options } = otherProps
@@ -34,6 +44,7 @@ const Dropdown = React.forwardRef(
     const classes = cx(className, size, {
       'inline-menu': inlineMenu,
       'keep-selected': shouldKeepSelected,
+      'no-selected-labels': noSelectedLabels,
       warning
     })
 
@@ -42,6 +53,8 @@ const Dropdown = React.forwardRef(
       icon: loading ? LOADING_ICON : icon,
       multiple: !!multiple,
       ref,
+      searchInput: noSelectedLabels ? { placeholder } : 'text',
+      placeholder: noSelectedLabels ? null : placeholder,
       ...otherProps
     }
 
@@ -71,6 +84,8 @@ Dropdown.propTypes = {
     PropTypes.bool,
     PropTypes.oneOf(_.values(MultipleModes))
   ]),
+  noSelectedLabels: PropTypes.bool,
+  placeholder: PropTypes.string,
   size: sizePropType,
   direction: directionPropType,
   warning: PropTypes.bool


### PR DESCRIPTION
Às vezes queremos um multiple dropdown que não mostre as opções selecionadas em labels. 

Temos um caso agora no produto em que quase todas as opções possuem o mesmo nome, sendo distinguidas por endereço, então seria esquisito mostrar as seleções todas com o mesmo nome.  Mostrar os endereços selecionados no lugar dos nomes seria muito grande também.

Outro caso é quando podem haver muitas seleções, pois as labels ocupam bastante espaço. E a gente já consegue mostrar as opções selecionadas no próprio dropdown menu, então essa informação não fica faltando.

Infelizmente o semantic ui não tem a opção de não renderizar as labels, então adicionei uma prop pra isso e estou escondendo-as pelo CSS.

**Antes**
<img width="425" alt="Screen Shot 2019-12-03 at 2 28 08 PM" src="https://user-images.githubusercontent.com/5216049/70074331-42bd2500-15d9-11ea-8306-16eedbc69897.png">

**Depois**
<img width="418" alt="Screen Shot 2019-12-03 at 2 27 47 PM" src="https://user-images.githubusercontent.com/5216049/70074330-42bd2500-15d9-11ea-96a6-713c519f855e.png">