### PR TITLE
feature(filter): Add prop for ignoring any apply actions

### DIFF
--- a/packages/orion/src/Filter/Filter.stories.js
+++ b/packages/orion/src/Filter/Filter.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import { object, text, withKnobs } from '@storybook/addon-knobs'
+import { object, text, withKnobs, boolean } from '@storybook/addon-knobs'
 import PropTypes from 'prop-types'
 import _ from 'lodash'
 
@@ -22,6 +22,7 @@ export default {
 export const withInput = () => (
   <Filter
     text={text('Label', 'Open')}
+    allowApply={boolean('Allow Apply', true)}
     extraFooterContent={text('Extra footer content', '')}
     {...actions}>
     {filterProps => (

--- a/packages/orion/src/Filter/Filter.test.js
+++ b/packages/orion/src/Filter/Filter.test.js
@@ -191,6 +191,22 @@ describe("when the filter's value changes", () => {
     })
   })
 
+  describe('when an element outside the filter is clicked', () => {
+    beforeEach(() => {
+      const { container } = renderResult
+      fireEvent.mouseUp(container.parentElement)
+    })
+
+    it('should render the selected value in the trigger', () => {
+      const { queryByText } = renderResult
+      expect(queryByText(newValue)).toBeTruthy()
+    })
+
+    it('should call "onApply" with the new value', () => {
+      expect(onApply).toHaveBeenCalledWith(newValue)
+    })
+  })
+
   describe('when the "ESC" key is pressed', () => {
     beforeEach(() => {
       const { getByPlaceholderText } = renderResult
@@ -218,8 +234,66 @@ describe("when the filter's value changes", () => {
       expect(onClear).toHaveBeenCalled()
     })
 
-    it('should call "onChange" with the "null"', () => {
+    it('should call "onChange" with "null"', () => {
       expect(onChange).toHaveBeenCalledWith(null)
+    })
+  })
+
+  describe('when applying is not allowed', () => {
+    beforeEach(() => {
+      const { rerender } = renderResult
+      rerender(
+        <Filter
+          allowApply={false}
+          text="Open"
+          onChange={onChange}
+          onClose={onClose}
+          onApply={onApply}
+          onClear={onClear}>
+          {childFn}
+        </Filter>
+      )
+    })
+
+    it('should not render the "apply" button', () => {
+      const { queryByText } = renderResult
+      expect(queryByText('Apply')).toBeNull()
+    })
+
+    it('should not render the "clear" button', () => {
+      const { queryByText } = renderResult
+      expect(queryByText('Clear')).toBeNull()
+    })
+
+    describe('when an element outside the filter is clicked', () => {
+      beforeEach(() => {
+        const { container } = renderResult
+        fireEvent.mouseUp(container.parentElement)
+      })
+
+      it('should not call "onApply" with the new value', () => {
+        expect(onApply).not.toHaveBeenCalled()
+      })
+
+      it('should call "onClose"', () => {
+        expect(onClose).toHaveBeenCalled()
+      })
+    })
+
+    describe('when the "ESC" key is pressed', () => {
+      beforeEach(() => {
+        const { getByPlaceholderText } = renderResult
+        const input = getByPlaceholderText('Input')
+        fireEvent.keyDown(input, { key: 'Escape', code: keyboardKey.Escape })
+      })
+
+      it('should not call "onApply" with the new value', () => {
+        expect(onApply).not.toHaveBeenCalled()
+      })
+
+      it('should call "onClose"', () => {
+        expect(onClose).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/packages/orion/src/Filter/filter.css
+++ b/packages/orion/src/Filter/filter.css
@@ -31,11 +31,11 @@
 }
 
 .orion.popup.filter .filter-content {
-  @apply p-8 pb-24;
+  @apply p-8;
 }
 
 .orion.popup.filter .filter-buttons {
-  @apply flex justify-between;
+  @apply flex justify-between pt-16;
 }
 
 .orion.popup.filter .filter-footer-content {


### PR DESCRIPTION
Queremos poder ter uma barra de filtros que possa controlar quando os valores dos filtros são aplicados. Ao invés de cada filtro ter seu próprio `Apply` ao ser fechado ou ao clicar em seu botão, só seria possível aplicar as mudanças de todos os filtros juntos, com um `Apply` geral nessa barra de filtros. Por exemplo:

<img width="1125" alt="Screen Shot 2020-01-03 at 12 00 57 PM" src="https://user-images.githubusercontent.com/5216049/71730375-bb094700-2e20-11ea-9408-ed094acc045f.png">

No entando, hoje o nosso componete `Filter` já lida com o `Apply` automaticamente. Para podermos construir essa barra de filtros precisamos que seja possível retirar essa responsabilidade do `Filter` para repassá-la para alguém que o chame.

Para isso eu criei uma prop chamada `allowApply` que por default tem o valor `true`, mantendo o comportamento atual de `Filter`. Caso ela seja passada como `false` porém, nós removemos o footer com o botão de `Apply` e também não fazemos `Apply` automático em ações como **ENTER**, **ESC** ou **click outside**. Resumindo, o `Filter` nunca faz `Apply`, deixando isso para quem chamá-lo controlar.

A idéia é depois ter um `FilterBar` que use essa prop em todos os filtros e lide com essa ação para todos ao mesmo tempo. 

Enfim, esse pr contém apenas essa nova prop.

**Default**
![2020-01-03 11 41 08](https://user-images.githubusercontent.com/5216049/71730692-982b6280-2e21-11ea-98f2-06c7e38e09ee.gif)

**Com `allowApply={false}`**
![2020-01-03 11 40 01](https://user-images.githubusercontent.com/5216049/71730691-982b6280-2e21-11ea-8595-f69d30b70963.gif)