### PR TITLE
feature(filter): Make filter trigger buttons more round

### DIFF
--- a/packages/orion/src/Button/button.css
+++ b/packages/orion/src/Button/button.css
@@ -1,5 +1,7 @@
 .orion.button {
   @apply h-40 rounded-full text-base font-default font-medium outline-none inline-flex items-center transition-default;
+  @apply px-24 justify-center;
+  min-width: 96px;
   transition-property: background-color, opacity;
 }
 
@@ -17,15 +19,10 @@
   vertical-align: sub;
 }
 
-.orion.button:not(.icon):not(.subtle) {
-  @apply px-24 justify-center;
-  min-width: 96px;
-}
-
 /* Icon only */
 
 .orion.button.icon {
-  @apply justify-center p-0 w-40;
+  @apply justify-center min-w-0 p-0 w-40;
 }
 
 .orion.button.icon:hover,
@@ -80,7 +77,7 @@
 /* Subtle */
 
 .orion.button.subtle {
-  @apply bg-transparent;
+  @apply bg-transparent min-w-0 p-0;
 }
 
 /* Subtle Primary */

--- a/packages/orion/src/Filter/filter.css
+++ b/packages/orion/src/Filter/filter.css
@@ -1,17 +1,22 @@
 .orion.button.filter-trigger {
-  @apply bg-white border border-gray-900-24 cursor-pointer font-normal rounded transition-default;
-  @apply inline-flex h-32 items-center text-gray-800;
+  @apply bg-white border border-gray-900-24 cursor-pointer font-normal transition-default;
+  @apply inline-flex h-32 items-center min-w-0 text-gray-800;
   @apply outline-none;
   @apply px-16 !important;
+  border-radius: 16px;
   transition-property: background-color, color;
 }
 
+.orion.button.filter-trigger.active,
 .orion.button.filter-trigger:hover,
 .orion.button.filter-trigger:focus {
   @apply bg-gray-900-8;
 }
 
-.orion.button.filter-trigger.active,
+.orion.button.filter-trigger.active:hover {
+  @apply bg-gray-900-16;
+}
+
 .orion.button.filter-trigger.selected {
   @apply bg-space-100 border-none text-space-900;
 
@@ -24,7 +29,6 @@
   padding-right: 17px !important;
 }
 
-.orion.button.filter-trigger.active:hover,
 .orion.button.filter-trigger.selected:hover,
 .orion.button.filter-trigger.selected:focus {
   @apply bg-space-200;


### PR DESCRIPTION
O estilo do botão do `Filter` mudou um pouco, pra ficar mais arredondado. Mudou também a cor usada quando ele está aberto.

**Antes**
<img width="497" alt="Screen Shot 2020-01-03 at 12 26 43 PM" src="https://user-images.githubusercontent.com/5216049/71731859-8ac3a780-2e24-11ea-8500-0c8cffbc5b19.png">

**Depois**
<img width="448" alt="Screen Shot 2020-01-03 at 12 26 21 PM" src="https://user-images.githubusercontent.com/5216049/71731858-8ac3a780-2e24-11ea-89c3-97465a40c017.png">