### PR TITLE
feature(button): Add "size" prop to `Button`

### DIFF
--- a/packages/orion/src/Button/Button.stories.js
+++ b/packages/orion/src/Button/Button.stories.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
 import { boolean, text, withKnobs } from '@storybook/addon-knobs/react'
+
 import Button from './'
+import { sizeKnob } from '../utils/stories'
 
 const actions = {
   onClick: action('onClick')
@@ -15,6 +17,7 @@ export default {
 
 export const primary = () => {
   const disabled = boolean('Disabled')
+  const sizeValue = sizeKnob()
   return (
     <React.Fragment>
       <Button
@@ -23,6 +26,7 @@ export const primary = () => {
         content={text('Content', 'Click Me')}
         disabled={disabled}
         icon={text('First Icon', '') || null}
+        size={sizeValue}
         {...actions}
       />
       <br />
@@ -32,6 +36,7 @@ export const primary = () => {
         primary
         disabled={disabled}
         icon={text('Second Icon', 'cloud')}
+        size={sizeValue}
         {...actions}
       />
     </React.Fragment>
@@ -40,6 +45,7 @@ export const primary = () => {
 
 export const secondary = () => {
   const disabled = boolean('Disabled')
+  const sizeValue = sizeKnob()
   return (
     <React.Fragment>
       <Button
@@ -48,6 +54,7 @@ export const secondary = () => {
         content={text('Content', 'Click Me')}
         disabled={disabled}
         icon={text('First Icon', '') || null}
+        size={sizeValue}
         {...actions}
       />
       <br />
@@ -57,6 +64,7 @@ export const secondary = () => {
         secondary
         disabled={disabled}
         icon={text('Second Icon', 'cloud')}
+        size={sizeValue}
         {...actions}
       />
     </React.Fragment>
@@ -65,6 +73,7 @@ export const secondary = () => {
 
 export const ghost = () => {
   const disabled = boolean('Disabled')
+  const sizeValue = sizeKnob()
   return (
     <React.Fragment>
       <Button
@@ -73,6 +82,7 @@ export const ghost = () => {
         content={text('Content', 'Click Me')}
         disabled={disabled}
         icon={text('First Icon', '') || null}
+        size={sizeValue}
         {...actions}
       />
       <br />
@@ -82,6 +92,7 @@ export const ghost = () => {
         ghost
         disabled={disabled}
         icon={text('Second Icon', 'cloud')}
+        size={sizeValue}
         {...actions}
       />
     </React.Fragment>
@@ -90,6 +101,7 @@ export const ghost = () => {
 
 export const subtlePrimary = () => {
   const disabled = boolean('Disabled')
+  const sizeValue = sizeKnob()
   return (
     <React.Fragment>
       <Button
@@ -99,6 +111,7 @@ export const subtlePrimary = () => {
         content={text('Content', 'Click Me')}
         disabled={disabled}
         icon={text('First Icon', '') || null}
+        size={sizeValue}
         {...actions}
       />
       <br />
@@ -109,6 +122,7 @@ export const subtlePrimary = () => {
         subtle
         disabled={disabled}
         icon={text('Second Icon', 'apps')}
+        size={sizeValue}
         {...actions}
       />
     </React.Fragment>
@@ -117,6 +131,7 @@ export const subtlePrimary = () => {
 
 export const subtleSecondary = () => {
   const disabled = boolean('Disabled')
+  const sizeValue = sizeKnob()
   return (
     <React.Fragment>
       <Button
@@ -126,6 +141,7 @@ export const subtleSecondary = () => {
         content={text('Content', 'Click Me')}
         disabled={disabled}
         icon={text('First Icon', '') || null}
+        size={sizeValue}
         {...actions}
       />
       <br />
@@ -136,6 +152,7 @@ export const subtleSecondary = () => {
         subtle
         disabled={disabled}
         icon={text('Second Icon', 'apps')}
+        size={sizeValue}
         {...actions}
       />
     </React.Fragment>

--- a/packages/orion/src/Button/button.css
+++ b/packages/orion/src/Button/button.css
@@ -19,6 +19,12 @@
   vertical-align: sub;
 }
 
+/* Sizes */
+
+.orion.button.small {
+  @apply h-32 min-w-0 px-16;
+}
+
 /* Icon only */
 
 .orion.button.icon {
@@ -32,6 +38,10 @@
 
 .orion.button.icon:active {
   @apply bg-gray-900-12;
+}
+
+.orion.button.icon.small {
+  @apply w-32;
 }
 
 /* Disabled */

--- a/packages/orion/src/Button/index.js
+++ b/packages/orion/src/Button/index.js
@@ -1,14 +1,21 @@
-import _ from 'lodash'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Button as SemanticButton } from '@inloco/semantic-ui-react'
 
+import { Sizes, sizePropType } from '../utils/sizes'
 import { createShorthandFactory } from '../utils/factories'
 
-const Button = ({ className, ghost, secondary, subtle, ...otherProps }) => {
+const Button = ({
+  className,
+  ghost,
+  secondary,
+  size,
+  subtle,
+  ...otherProps
+}) => {
   const { primary } = otherProps
-  const classes = cx(className, { ghost, subtle })
+  const classes = cx(className, size, { ghost, subtle })
   return (
     <SemanticButton
       className={classes}
@@ -19,8 +26,15 @@ const Button = ({ className, ghost, secondary, subtle, ...otherProps }) => {
 }
 
 Button.propTypes = {
+  className: PropTypes.string,
   ghost: PropTypes.bool,
+  secondary: PropTypes.bool,
+  size: sizePropType,
   subtle: PropTypes.bool
+}
+
+Button.defaultProps = {
+  size: Sizes.DEFAULT
 }
 
 // Overriding original factory. See src/utils/factories.js for more details.

--- a/packages/orion/src/Filter/filter.css
+++ b/packages/orion/src/Filter/filter.css
@@ -2,9 +2,8 @@
 
 .orion.button.filter-trigger {
   @apply bg-white border border-gray-900-24 cursor-pointer font-normal transition-default;
-  @apply inline-flex h-32 items-center min-w-0 text-gray-800;
+  @apply inline-flex items-center text-gray-800;
   @apply outline-none;
-  @apply px-16;
   transition-property: background-color, color;
 }
 

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 
 import { Button, ClickOutside, Popup } from '../'
+import { Sizes } from '../utils/sizes'
 import FilterClearIcon from './FilterClearIcon'
 
 const Filter = ({
@@ -84,7 +85,10 @@ const Filter = ({
     selected: isSelected
   })
   const trigger = (
-    <Button className={triggerClasses} onClick={handleTriggerClick}>
+    <Button
+      className={triggerClasses}
+      onClick={handleTriggerClick}
+      size={Sizes.SMALL}>
       {isSelected ? selectedText(value) : text}
       {isSelected && <FilterClearIcon onClick={handleClearIconClick} />}
     </Button>


### PR DESCRIPTION
O componente `Filter` usa buttons mas com um tamanho menor. Ele mesmo estava dando override no button para conseguir isso. Mas acredito que faça mais sentido `Button` ter uma prop para controlar melhor esses tamanhos, como já temos para outros componentes. Da mesma forma que pra os outros, ele só tem duas opções de tamanho: **default** e **small**.

![2020-01-06 11 49 38](https://user-images.githubusercontent.com/5216049/71825512-ce175380-307a-11ea-87bd-e2895819a135.gif)
