### PR TITLE
fix(filterBar): Fix different references of the same `value` reseting the local value

### DIFF
--- a/packages/orion/src/FilterBar/index.js
+++ b/packages/orion/src/FilterBar/index.js
@@ -22,10 +22,6 @@ const FilterBar = ({
 
   const [localValue, setLocalValue] = useState(value)
 
-  useEffect(() => {
-    setLocalValue(value)
-  }, [value])
-
   const pendingFilters = {}
   React.Children.forEach(children, child => {
     const name = child.props.name
@@ -45,6 +41,8 @@ const FilterBar = ({
   const updateValue = newValue => {
     setValue(newValue)
     onChange && onChange(newValue)
+
+    setLocalValue(newValue)
   }
 
   const shouldRenderClearAllButton = !hasPendingFilters && !_.isEmpty(value)


### PR DESCRIPTION
Da forma que eu fiz o código, se a cada vez que `FilterBar` fosse renderizado com alguma prop nova, a gente repassasse um objeto `value` novo, o local value era atualizado com este objeto.

Isso causa bugs frequentemente, pois é comum passar `value` sempre como um novo objeto por conta de concatenações spread, mesmo que o resultado final seja igual ao `value` anterior. Nesse caso não era pra local value mudar, pois ele perde o valor pendente e fica voltando para o valor anterior dos filtros.

Daria pra adaptar o código que estava lá para funcionar, guardando o valor antigo em uma ref e checando se o novo valor é realmente diferente, mas isso deixa o código mais complexo e não tem necessidade. Troquei por algo mais simples e correto.