### PR TITLE
chore(circleci): Add lint checks and skip gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
             - ~/.cache/yarn
             - node_modules
       - run:
+          name: Run Lint Checks
+          command: yarn orion:lint --max-warnings=0 --format junit --output-file ../../reports/junit/eslint.xml
+      - run:
           name: Run Tests
           command: yarn workspace @inloco/orion test --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
-version: 2
+version: 2.1
 
 jobs:
-  build:
+  test:
     docker:
       - image: circleci/node:12.2.0-stretch
     steps:
@@ -26,5 +26,12 @@ jobs:
           command: yarn workspace @inloco/orion test --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
       - store_test_results:
           path: ./reports
-    branches:
-      ignore: gh-pages
+
+workflows:
+  version: 2.1
+  test:
+    jobs:
+      - test:
+          filters:
+            branches:
+              ignore: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
+reports
 .cache


### PR DESCRIPTION
Agora o lint pode rodar a cada build da gente pra detectar os erros.

Aproveita pra tentar corrigir o skip de gh-pages também. Hoje o job sempre falha quando é pra esse branch, porque o código que vai pra lá é diferente mesmo, não inclui os testes. Já tínhamos configuração pra ignorar isso, mas ela não funcionava. Parece que só dá pra ignorar branches em workflows, mas não em jobs. 