### PR TITLE
feat(Message): Add info option

### DIFF
--- a/packages/orion/src/Message/Message.stories.js
+++ b/packages/orion/src/Message/Message.stories.js
@@ -16,6 +16,7 @@ export const basic = () => (
     error={boolean('Error', false)}
     success={boolean('Success', false)}
     warning={boolean('Warning', false)}
+    info={boolean('Info', false)}
     fluid={boolean('Fluid', false)}
   />
 )
@@ -26,6 +27,7 @@ export const inline = () => (
     error={boolean('Error', false)}
     success={boolean('Success', false)}
     warning={boolean('Warning', false)}
+    info={boolean('Info', false)}
     fluid={boolean('Fluid', false)}
   />
 )
@@ -38,6 +40,7 @@ export const dismissible = () => (
     success={boolean('Success', false)}
     warning={boolean('Warning', false)}
     fluid={boolean('Fluid', false)}
+    info={boolean('Info', false)}
     onDismiss={action('onDimiss')}
   />
 )

--- a/packages/orion/src/Message/index.js
+++ b/packages/orion/src/Message/index.js
@@ -11,6 +11,7 @@ const Message = ({
   warning,
   fluid,
   className,
+  info,
   onDismiss,
   ...otherProps
 }) => {
@@ -25,6 +26,7 @@ const Message = ({
     error,
     success,
     warning,
+    info,
     header
   })
 
@@ -32,6 +34,8 @@ const Message = ({
     <Icon name="warning" className="text-yellow-500" />
   ) : error ? (
     <Icon name="error" className="text-magenta-500" />
+  ) : info ? (
+    <Icon name="info_outline" className="text-gray-700" />
   ) : (
     <Icon name="check" className="text-green-500" />
   )
@@ -60,6 +64,7 @@ Message.propTypes = {
   onDismiss: PropTypes.func,
   success: PropTypes.bool,
   warning: PropTypes.bool,
+  info: PropTypes.bool,
   fluid: PropTypes.bool
 }
 

--- a/packages/orion/src/Message/message.css
+++ b/packages/orion/src/Message/message.css
@@ -6,6 +6,10 @@
   @apply font-medium;
 }
 
+.orion.message.info {
+  @apply border-gray-900-8 bg-gray-100;
+}
+
 .orion.message.error {
   @apply border-magenta-500 bg-magenta-50;
 }


### PR DESCRIPTION
Adicionei a possibilidade do component Message ter esse estilo Info, pois será utilizado na página de Competidores

Como será utilizado:
![Screen Shot 2020-01-08 at 16 07 03](https://user-images.githubusercontent.com/19842645/72007681-f648b300-3230-11ea-9144-bb4819efdf3f.png)

Imagens: 
![Screen Shot 2020-01-08 at 16 04 34](https://user-images.githubusercontent.com/19842645/72007601-cdc0b900-3230-11ea-8289-8d04edff650f.png)
![Screen Shot 2020-01-08 at 16 05 08](https://user-images.githubusercontent.com/19842645/72007602-cdc0b900-3230-11ea-9a58-7ffeaab438ea.png)
![Screen Shot 2020-01-08 at 16 05 22](https://user-images.githubusercontent.com/19842645/72007603-cdc0b900-3230-11ea-852e-9be13c5e578c.png)
y6