### PR TITLE
chore(prop-types): Fix type of "as" prop in "Icon"

### DIFF
--- a/packages/orion/src/Icon/index.js
+++ b/packages/orion/src/Icon/index.js
@@ -25,7 +25,7 @@ Icon.propTypes = {
   className: PropTypes.string,
   color: PropTypes.string,
   name: PropTypes.string,
-  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+  as: PropTypes.elementType
 }
 
 // Overriding original factory. See src/utils/factories.js for more details.


### PR DESCRIPTION
Existe uma PropType melhor pra esse caso de uso: `PropTypes.elementType`. Eu nem conhecia, mas notei que quando passamos um componente SVG pra essa prop ela dá warning no 4apps, apesar de funcionar no componente. Então vi que no semantic ui eles usam esse tipo e realmente isso faz o warning sumir. Então corrigi aqui.