### PR TITLE
feature(dropdown): Make "selectOnBlur" and "selectOnNavigation" props from Dropdown be false by default

### DIFF
--- a/packages/orion/src/Dropdown/index.js
+++ b/packages/orion/src/Dropdown/index.js
@@ -86,6 +86,8 @@ Dropdown.propTypes = {
   ]),
   noSelectedLabels: PropTypes.bool,
   placeholder: PropTypes.string,
+  selectOnBlur: PropTypes.bool,
+  selectOnNavigation: PropTypes.bool,
   size: sizePropType,
   direction: directionPropType,
   warning: PropTypes.bool
@@ -95,7 +97,9 @@ Dropdown.defaultProps = {
   deburr: true,
   icon: DROPDOWN_ICON,
   size: Sizes.DEFAULT,
-  direction: Directions.LEFT
+  direction: Directions.LEFT,
+  selectOnBlur: false,
+  selectOnNavigation: false
 }
 
 Dropdown.Divider = Divider


### PR DESCRIPTION
Essas props são `true` por default no semantic, mas causam um comportamento muuuito esquisito que nós estamos sempre desabilitando ao usar o `Dropdown` na In Loco.

`selectOnBlur` faz com que o primeiro elemento do `Dropdown` seja selecionado assim que ele é aberto, mesmo que ninguém clique nele. Então se a pessoa apenas abrir e fechar sem fazer nada, o primeiro elemento é selecionado por default.

`selectOnNavigation` faz com que os elementos sejam selecionados ao passar por eles com as setas do teclado, mesmo que o usuário nunca aperte enter nem selecione de fato. 

Ambos fazem muito mais sentido como `false` por default, e como estamos sempre tendo que fazer isso mesmo eu acho uma boa aproveitar pra deixar assim no Orion.

**Antes**
![2020-01-17 13 18 58](https://user-images.githubusercontent.com/5216049/72628141-80c59c80-392c-11ea-9052-003bc8ce8d6a.gif)

**Depois**
![2020-01-17 13 18 28](https://user-images.githubusercontent.com/5216049/72628140-80c59c80-392c-11ea-9fc8-184045bb8df1.gif)