### PR TITLE
chore(prop-types): Fix prop types warning on Menu

### DIFF
--- a/packages/orion/src/Menu/index.js
+++ b/packages/orion/src/Menu/index.js
@@ -3,13 +3,20 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Menu as SemanticMenu } from '@inloco/semantic-ui-react'
 
-const Menu = ({ className, switcher, ...otherProps }) => (
-  <SemanticMenu className={cx(className, { switcher })} {...otherProps} />
+import { Sizes, sizePropType } from '../utils/sizes'
+
+const Menu = ({ className, size, switcher, ...otherProps }) => (
+  <SemanticMenu className={cx(className, size, { switcher })} {...otherProps} />
 )
 
 Menu.propTypes = {
   className: PropTypes.string,
+  size: sizePropType,
   switcher: PropTypes.bool
+}
+
+Menu.defaultProps = {
+  size: Sizes.DEFAULT
 }
 
 Menu.Header = SemanticMenu.Header


### PR DESCRIPTION
Eu notei esse warning do React agora no storybook do `Menu`, reclamando da prop `size`.

Isso é só uma besteira que eu esqueci de avisar ao revisar o pr https://github.com/inloco/orion/pull/442. Basicamente é porque o semantic tem 6 definições de `size` (como dá pra ver no warning que eles lançam abaixo), mas a gente só usa 2: **small** e **default**. Ao invés de permitir passar qualquer valor do semantic, o que poderia gerar alguma confusão quando não funcionasse, eu achei melhor limitar o nosso lado a apenas esses 2 mesmo. 

Mas pra isso funcionar a gente tem que sempre dar override na prop do componente e repassar pra o `className` manualmente, ignorando os prop types do semantic.

Não fazer isso nem daria erro, mas como eu achei melhor definir o default como vazio, e o semantic não aceita size vazio, acaba dando esse warning. No fim das contas é bom que força a gente a definir melhor nossos prop types, e o resultado final na DOM fica mais clean também :)

<img width="1440" alt="Screen Shot 2020-01-20 at 11 49 53 AM" src="https://user-images.githubusercontent.com/5216049/72736031-bb714400-3b7b-11ea-8272-87c3ae7aea49.png">
