### PR TITLE
Fix/minor fixes

### DIFF
--- a/packages/orion/src/Checkbox/Checkbox.stories.js
+++ b/packages/orion/src/Checkbox/Checkbox.stories.js
@@ -11,7 +11,7 @@ export default {
 export const regular = () => (
   <React.Fragment>
     <Checkbox
-      label={text('Label', 'Click Me')}
+      label={!boolean('No label', false) && text('Label', 'Click Me')}
       defaultChecked
       indeterminate={boolean('Indeterminate', false)}
       disabled={boolean('Disabled', false)}

--- a/packages/orion/src/Checkbox/checkbox.css
+++ b/packages/orion/src/Checkbox/checkbox.css
@@ -1,11 +1,15 @@
 .orion.checkbox {
-  @apply my-2 relative;
+  @apply my-2 relative h-16;
 }
 
 .orion.checkbox input[type='checkbox'] {
   @apply absolute top-0 left-0 h-16 w-16;
   @apply opacity-0;
   @apply block !important;
+}
+
+.orion.checkbox.fitted > label {
+  @apply pl-0;
 }
 
 .orion.checkbox input[type='checkbox'] ~ label {
@@ -15,7 +19,7 @@
 
 .orion.checkbox input[type='checkbox'] ~ label:before {
   @apply absolute top-0 left-0 h-16 w-16;
-  @apply border border-gray-900-24 rounded;
+  @apply border border-gray-900-24 bg-white rounded;
   content: '';
 }
 

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -35,7 +35,7 @@
 }
 
 .orion.dropdown > .menu {
-  @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full;
+  @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full z-10;
   top: 100%;
 }
 


### PR DESCRIPTION
Fazendo alguns pequenos fixes em alguns componentes.
1. Dropdown - O Menu está posicionado atrás de qualquer elemento que esteja após ele no HTML. Então estou aumentando o z-index pra ele ir pra frente do que estiver em 0.
![orion-form](https://user-images.githubusercontent.com/9112403/72753927-0a7f9f00-3ba5-11ea-99c2-15aa1a9077e8.gif)

2. Checkbox - Estava sem o fundo branco, usando apenas o componente nativo e ficando transparente (no Chrome). Estava faltando apenas o `bg-white` no `:before`. Além disso, percebemos que o Checkbox estava estranhamente com uma largura de 24px quando estava sem label. Isso acontece pq a `.label` do checkbox tem um padding-left de 24px. Quando a label estava vazia, esse padding persistia e nao deixava o checkbox ficar menor que isso. O semantic adiciona uma classe `.fitted` quando não tem label, e usa essa classe para remover esse padding da label para evitar esse comportamento. Então estou corrigindo fazendo o mesmo e adicionando um `pl-0` para a label do `.fitted`.
Como era antes: ![Screen Shot 2020-01-20 at 12 35 34](https://user-images.githubusercontent.com/9112403/72754125-baeda300-3ba5-11ea-966d-1816bf0190ba.png)


