### PR TITLE
Feature/pagination placeholder

### DIFF
--- a/packages/orion/src/Card/index.js
+++ b/packages/orion/src/Card/index.js
@@ -1,9 +1,7 @@
 import cx from 'classnames'
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Card as SemanticCard } from '@inloco/semantic-ui-react'
-
-import { Checkbox } from '../'
+import { Checkbox, Card as SemanticCard } from '@inloco/semantic-ui-react'
 
 const Card = ({
   children,

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -3,8 +3,11 @@ import keyboardKey from 'keyboard-key'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
+import { Popup } from '@inloco/semantic-ui-react'
 
-import { Button, ClickOutside, Popup, Tooltip } from '../'
+import Button from '../Button'
+import ClickOutside from '../ClickOutside'
+import Tooltip from '../Tooltip'
 import { Sizes } from '../utils/sizes'
 import FilterClearIcon from './FilterClearIcon'
 

--- a/packages/orion/src/FullscreenContainer/index.js
+++ b/packages/orion/src/FullscreenContainer/index.js
@@ -2,8 +2,9 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import _ from 'lodash'
+import { Portal } from '@inloco/semantic-ui-react'
 
-import { Button, Portal } from '../'
+import Button from '../Button'
 
 const FullscreenContainer = ({
   title,

--- a/packages/orion/src/Pagination/Pagination.stories.js
+++ b/packages/orion/src/Pagination/Pagination.stories.js
@@ -27,6 +27,7 @@ export const basic = () => (
       of: 'of',
       results: 'results'
     })}
+    loading={boolean('loading', false)}
     {...actions}
   />
 )

--- a/packages/orion/src/Pagination/index.js
+++ b/packages/orion/src/Pagination/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
+import { Placeholder } from '@inloco/semantic-ui-react'
 
-import { Placeholder, Button } from '../'
+import Button from '../Button'
 
 const ACTIVE_PAGE_MIN = 1
 

--- a/packages/orion/src/Pagination/index.js
+++ b/packages/orion/src/Pagination/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
-import Button from '../Button'
+import { Placeholder, Button } from '../'
 
 const ACTIVE_PAGE_MIN = 1
 
@@ -17,13 +17,24 @@ const Pagination = ({
   pageSize,
   alignButtonsLeft,
   totalItems,
+  loading,
   ...otherProps
 }) => {
-  if (pageSize < 1) return null
+  if (!loading && pageSize < 1) return null
 
   const orionPaginationClasses = cx('orion-pagination', className, {
     'orion-pagination-align-buttons-left': alignButtonsLeft
   })
+
+  if (loading) {
+    return (
+      <div className={orionPaginationClasses} {...otherProps}>
+        <Placeholder className="orion-pagination-placeholder">
+          <Placeholder.Line length="full" />
+        </Placeholder>
+      </div>
+    )
+  }
 
   const orionPaginationContent = cx({
     'orion-pagination-content-disabled': disabled
@@ -36,6 +47,7 @@ const Pagination = ({
   )
   const firstPageItem = pageSize * (possibleActivePage - 1) + 1
   const lastPageItem = Math.min(pageSize * possibleActivePage, totalItems)
+
   return (
     <div className={orionPaginationClasses} {...otherProps}>
       <div className={orionPaginationContent}>
@@ -93,6 +105,7 @@ Pagination.propTypes = {
   pageSize: PropTypes.number,
   alignButtonsLeft: PropTypes.bool,
   totalItems: PropTypes.number.isRequired,
+  loading: PropTypes.bool,
   className: PropTypes.string,
   i18n: PropTypes.shape({
     of: PropTypes.string,

--- a/packages/orion/src/Pagination/pagination.css
+++ b/packages/orion/src/Pagination/pagination.css
@@ -8,7 +8,11 @@
 }
 
 .orion-pagination-actions {
-  @apply ml-8;
+  @apply ml-8 inline-flex;
+}
+
+.orion-pagination-placeholder {
+  min-width: 152px;
 }
 
 .orion-pagination-align-buttons-left .orion-pagination-actions {

--- a/packages/orion/src/Placeholder/Placeholder.css
+++ b/packages/orion/src/Placeholder/Placeholder.css
@@ -3,16 +3,7 @@
 --------------------*/
 
 .orion.placeholder {
-  @apply static overflow-hidden bg-white max-w-384;
-  animation: placeholderShimmer 2s linear;
-  animation-iteration-count: infinite;
-  background-image: linear-gradient(
-    to right,
-    rgba(0, 0, 0, 0.08) 0%,
-    rgba(0, 0, 0, 0.15) 15%,
-    rgba(0, 0, 0, 0.08) 30%
-  );
-  background-size: 1200px 100%;
+  @apply static overflow-hidden bg-white max-w-384 w-full;
 }
 
 @keyframes placeholderShimmer {
@@ -28,7 +19,7 @@
 .orion.placeholder > :before,
 .orion.placeholder .line,
 .orion.placeholder .line:after {
-  background-color: inherit;
+  background-color: transparent;
 }
 
 /*---------------
@@ -36,7 +27,21 @@
 ----------------*/
 
 .orion.placeholder .line {
-  @apply relative h-8 mb-8;
+  @apply relative h-8 mt-4 mb-8;
+
+  animation: placeholderShimmer 2s linear;
+  animation-iteration-count: infinite;
+  background-image: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.08) 0%,
+    rgba(0, 0, 0, 0.15) 15%,
+    rgba(0, 0, 0, 0.08) 30%
+  );
+  background-size: 1200px 100%;
+}
+
+.orion.placeholder .line:last-child {
+  @apply mb-4;
 }
 
 .orion.placeholder .line:before,
@@ -59,28 +64,28 @@
         Sizes
 --------------------*/
 
-.orion.placeholder .full.line:after {
-  @apply w-0;
+.orion.placeholder .full.line {
+  @apply w-full;
 }
 
-.orion.placeholder .very.long.line:after {
-  @apply w-1/6;
+.orion.placeholder .very.long.line {
+  @apply w-5/6;
 }
 
-.orion.placeholder .long.line:after {
-  @apply w-2/6;
-}
-
-.orion.placeholder .medium.line:after {
-  @apply w-3/6;
-}
-
-.orion.placeholder .short.line:after {
+.orion.placeholder .long.line {
   @apply w-4/6;
 }
 
-.orion.placeholder .very.short.line:after {
-  @apply w-5/6;
+.orion.placeholder .medium.line {
+  @apply w-3/6;
+}
+
+.orion.placeholder .short.line {
+  @apply w-2/6;
+}
+
+.orion.placeholder .very.short.line {
+  @apply w-1/6;
 }
 
 /*-------------------


### PR DESCRIPTION
Adicionando um estado de "Loading" no componente `Pagination` e aproveitando pra corrigir um comportamento que nos incomodava no `Placeholder`.

O estilo do placeholder no semantic (que foi copiado para o Orion) define uma animação no background do container (`<Placeholder/>`), e cada linha dentro defini uma margin (que é transparente) e um background de cor herdada dos pais (com `inherit`). Isso nos incomoda por duas razões: 
1. Sempre precisamos ter um background-color definido no componente que renderiza o Placeholder, para que essa cor seja repassada até chegar nas lines e criar a separação. Caso não tenha (ou seja `transparent`) as linhas não vão "apagar" a animação e ficaria assim:
![orion-placeholder](https://user-images.githubusercontent.com/9112403/72755268-dc03c300-3ba8-11ea-9785-b98e99b24018.gif)

2. Esse background "apagando" a animação na verdade sempre vai deixar uma cor sólida no placeholder, então embora pareça, não podemos ter transparência real entre as linhas. Alguns componentes precisam ter background transparente, o que impossibilita o uso do Placeholder da forma atual.

Então estou corrigindo o Placeholder tirando a animação do container `.placeholder` e colocando em cada `.placeholder .line`. Assim conseguimos ter o mesmo efeito de antes e não ficamos dependendo de um `background-color` herdado dos pais. O espaço entre as linhas é de fato transparente. 

Além disso, as linhas antes ocupavam visualmente apenas a metade inferior do seu espaço. Isso fazia o placeholder parecer desalinhado em varios casos, como o que estou adicionando de paginação. Então estou deixando o placeholder centralizado com 4px de margin para ambos os lados caso (continuando com 8x entre eles).
![orion-pagination-placeholder](https://user-images.githubusercontent.com/9112403/72755760-0ace6900-3baa-11ea-9d84-f094a3cc1e24.gif)




