### PR TITLE
feature(dialog): Change the color and icons for Dialog

### DIFF
--- a/packages/orion/src/Dialog/Dialog.stories.js
+++ b/packages/orion/src/Dialog/Dialog.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { text, boolean, withKnobs } from '@storybook/addon-knobs'
 
-import { Button, Dialog, Icon } from '../'
+import { Button, Dialog } from '../'
 
 export default {
   title: 'Dialog',
@@ -14,10 +14,7 @@ export const standard = () => {
       trigger={<Button>Open Dialog</Button>}
       warning={boolean('Warning', false)}
       danger={boolean('Danger', false)}>
-      <Dialog.Header>
-        <Icon name="warning" className="mb-8" />
-        {text('Title', 'Dialog Title')}
-      </Dialog.Header>
+      <Dialog.Header>{text('Title', 'Dialog Title')}</Dialog.Header>
       <Dialog.Content>
         {text(
           'Content',

--- a/packages/orion/src/Dialog/dialog.css
+++ b/packages/orion/src/Dialog/dialog.css
@@ -15,7 +15,7 @@
 ---------------*/
 
 .orion.modal.dialog > .header {
-  @apply flex flex-col font-default font-medium text-base text-wave-500;
+  @apply flex flex-col font-default font-medium text-base text-space-600;
 }
 
 /*--------------
@@ -43,6 +43,10 @@
 ---------------*/
 
 .orion.modal.dialog.warning > .header {
+  @apply text-yellow-700;
+}
+
+.orion.modal.dialog.warning > .header .icon {
   @apply text-yellow-500;
 }
 
@@ -62,6 +66,10 @@
 ---------------*/
 
 .orion.modal.dialog.danger > .header {
+  @apply text-magenta-600;
+}
+
+.orion.modal.dialog.danger > .header .icon {
   @apply text-magenta-500;
 }
 

--- a/packages/orion/src/Dialog/dialog.css
+++ b/packages/orion/src/Dialog/dialog.css
@@ -18,6 +18,11 @@
   @apply flex flex-col font-default font-medium text-base text-space-600;
 }
 
+.orion.modal.dialog > .header::before {
+  @apply font-icons mb-8 text-lg text-space-600;
+  content: 'info';
+}
+
 /*--------------
      Content
 ---------------*/
@@ -46,8 +51,9 @@
   @apply text-yellow-700;
 }
 
-.orion.modal.dialog.warning > .header .icon {
+.orion.modal.dialog.warning > .header::before {
   @apply text-yellow-500;
+  content: 'warning';
 }
 
 .orion.modal.dialog.warning .actions > .button.primary {
@@ -69,8 +75,9 @@
   @apply text-magenta-600;
 }
 
-.orion.modal.dialog.danger > .header .icon {
+.orion.modal.dialog.danger > .header::before {
   @apply text-magenta-500;
+  content: 'error';
 }
 
 .orion.modal.dialog.danger .actions > .button.primary {


### PR DESCRIPTION
Eu notei umas diferenças sutis nas cores que estavam sendo usadas para o header de cada tipo de **Dialog**. Ajustei elas aqui.

Também notei que o ícone usado deveria ser diferente pra cada tipo, mas no storybook a gente usava sempre o mesmo. E como já comecei a usar no 4apps achei meio repetitivo ficar adicionando esse ícone na mão, então mudei o **Dialog** pra adicionar automaticamente o ícone correto por CSS.

**Antes (default)**
<img width="527" alt="Screen Shot 2020-01-21 at 2 40 27 PM" src="https://user-images.githubusercontent.com/5216049/72829830-4c205080-3c5e-11ea-8ecb-edf5267b1081.png">

**Depois (default)**
<img width="521" alt="Screen Shot 2020-01-21 at 2 52 13 PM" src="https://user-images.githubusercontent.com/5216049/72829835-4d517d80-3c5e-11ea-94dd-272dc1ebb3ec.png">

**Antes (warning)**
<img width="531" alt="Screen Shot 2020-01-21 at 2 38 05 PM" src="https://user-images.githubusercontent.com/5216049/72829828-4b87ba00-3c5e-11ea-91ba-f65b838fc4f6.png">

**Depois (warning)**
<img width="526" alt="Screen Shot 2020-01-21 at 2 52 09 PM" src="https://user-images.githubusercontent.com/5216049/72829834-4cb8e700-3c5e-11ea-8b14-45ea88801f5d.png">

**Antes (danger)**
<img width="519" alt="Screen Shot 2020-01-21 at 2 39 03 PM" src="https://user-images.githubusercontent.com/5216049/72829829-4c205080-3c5e-11ea-9d83-70bb0de8f5ef.png">

**Depois (danger)**
<img width="523" alt="Screen Shot 2020-01-21 at 2 52 04 PM" src="https://user-images.githubusercontent.com/5216049/72829831-4c205080-3c5e-11ea-9f91-90c1b3aac5e6.png">
