### PR TITLE
feature(dimmer): Add a darker version of the dimmer and use it for global modals

### DIFF
--- a/packages/orion/src/Dialog/index.js
+++ b/packages/orion/src/Dialog/index.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Modal as SemanticModal } from '@inloco/semantic-ui-react'
 import cx from 'classnames'
 
+import Modal from '../Modal'
+
 const Dialog = ({ className, warning, danger, ...otherProps }) => (
-  <SemanticModal
+  <Modal
     className={cx(className, 'dialog', {
       warning,
       danger
@@ -19,9 +20,9 @@ Dialog.propTypes = {
   warning: PropTypes.bool
 }
 
-Dialog.Actions = SemanticModal.Actions
-Dialog.Content = SemanticModal.Content
-Dialog.Description = SemanticModal.Description
-Dialog.Header = SemanticModal.Header
+Dialog.Actions = Modal.Actions
+Dialog.Content = Modal.Content
+Dialog.Description = Modal.Description
+Dialog.Header = Modal.Header
 
 export default Dialog

--- a/packages/orion/src/Dimmer/Dimmer.stories.js
+++ b/packages/orion/src/Dimmer/Dimmer.stories.js
@@ -24,7 +24,10 @@ export const basic = () => {
         adipisci! Dolorum aspernatur laborum sapiente aliquid.
       </div>
       <Button primary>Lorem Lorem</Button>
-      <Dimmer active={boolean('Active', true)} />
+      <Dimmer
+        active={boolean('Active', true)}
+        inverted={boolean('Inverted', false)}
+      />
     </div>
   )
 }

--- a/packages/orion/src/Dimmer/dimmer.css
+++ b/packages/orion/src/Dimmer/dimmer.css
@@ -8,3 +8,7 @@
 .orion.dimmer.active {
   @apply opacity-100 pointer-events-auto;
 }
+
+.orion.dimmer.inverted {
+  background-color: rgba(0, 0, 0, 0.66);
+}

--- a/packages/orion/src/Modal/index.js
+++ b/packages/orion/src/Modal/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Modal as SemanticModal } from '@inloco/semantic-ui-react'
+
+const Modal = props => <SemanticModal {...props} />
+
+Modal.defaultProps = {
+  dimmer: 'inverted'
+}
+
+Modal.Actions = SemanticModal.Actions
+Modal.Content = SemanticModal.Content
+Modal.Description = SemanticModal.Description
+Modal.Header = SemanticModal.Header
+
+export default Modal

--- a/packages/orion/src/index.js
+++ b/packages/orion/src/index.js
@@ -3,7 +3,6 @@ export { default as Colors } from '@inloco/atomic-bomb'
 export {
   Checkbox,
   Dimmer,
-  Modal,
   Placeholder,
   Popup,
   Portal,
@@ -31,6 +30,7 @@ export { default as LoadingBar } from './LoadingBar'
 export { default as Logo } from './Logo'
 export { default as Menu } from './Menu'
 export { default as Message } from './Message'
+export { default as Modal } from './Modal'
 export { default as NotificationCenter } from './NotificationCenter'
 export { default as Pagination } from './Pagination'
 export { default as Progress } from './Progress'


### PR DESCRIPTION
Bruno me explicou que precisamos de dois tipos de dimmer:

> O branquinho é indicado pra quando for um popup que surja in-context (no caso dos filtros de insights por exemplo) enquanto o escuro ajuda a dar mais destaque a modais/alerts.

Peguei o estilo do dimmer escuro no Invision e aproveitei a prop `inverted` do semantic pra isso. Deixei esse escuro como o default pra `Modal`  e `Dialog`, mas é possível trocar se necessário através da prop `dimmer` que o semantic fornece.

**Antes (Modal)**
<img width="1227" alt="Screen Shot 2020-01-21 at 3 10 32 PM" src="https://user-images.githubusercontent.com/5216049/72831249-382a1e00-3c61-11ea-8757-ef02ff124ac7.png">

**Depois (Modal)**
<img width="1223" alt="Screen Shot 2020-01-21 at 3 14 08 PM" src="https://user-images.githubusercontent.com/5216049/72831254-395b4b00-3c61-11ea-9125-21d42c11d329.png">

**Antes (Dialog)**
<img width="1224" alt="Screen Shot 2020-01-21 at 3 13 42 PM" src="https://user-images.githubusercontent.com/5216049/72831252-38c2b480-3c61-11ea-8ceb-7a52e823fd60.png">

**Depois (Dialog)**
<img width="1223" alt="Screen Shot 2020-01-21 at 3 13 31 PM" src="https://user-images.githubusercontent.com/5216049/72831250-38c2b480-3c61-11ea-8d4e-69e54556f0c5.png">