### PR TITLE
feat(storybook-deployer): add [ci skip] to storybook commit message

### DIFF
--- a/packages/orion/package.json
+++ b/packages/orion/package.json
@@ -87,5 +87,8 @@
   "jest-junit": {
     "outputDirectory": "./reports/junit",
     "outputName": "./jest.xml"
+  },
+  "storybook-deployer": {
+    "commitMessage": "Deploy Storybook to GitHub Pages [ci skip]"
   }
 }


### PR DESCRIPTION
Sempre que o processo de deploy faz um commit pra branch `gh-pages`, o circle CI faz um build que falha. Isso acontece pq a branch não tem o arquivo `.circleci/config.yml`.

Encontrei [aqui](https://circleci.com/docs/2.0/skip-build/) que se adicionarmos "[ci skip]" ou "[skip ci]" na mensagem de commmit, o circle-ci vai ignorar aquele commit. 

Então estou atualizando a mensagem do commit que o `storybook-deployer` faz, como descrito aqui:
https://github.com/storybookjs/storybook-deployer#custom-deploy-configuration