### PR TITLE
fix(slider): Fix slider when passing classname

### DIFF
--- a/packages/orion/src/Slider/Slider.stories.css
+++ b/packages/orion/src/Slider/Slider.stories.css
@@ -1,0 +1,3 @@
+.custom-slider input[type='range'].orion-slider::-webkit-slider-runnable-track {
+  background-color: #f00;
+}

--- a/packages/orion/src/Slider/Slider.stories.js
+++ b/packages/orion/src/Slider/Slider.stories.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { withKnobs, number } from '@storybook/addon-knobs'
 
 import { Slider } from '..'
+import './Slider.stories.css'
 
 export default {
   title: 'Slider',
@@ -21,4 +22,8 @@ export const MinMaxAndStep = () => {
       labelsMask={value => 'R$ ' + value}
     />
   )
+}
+
+export const CustomTrackColor = () => {
+  return <Slider className="custom-slider" />
 }

--- a/packages/orion/src/Slider/index.js
+++ b/packages/orion/src/Slider/index.js
@@ -2,8 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import SliderPopup from './SliderPopup'
+import cx from 'classnames'
 
-const Slider = ({ onChange, labelsMask, ...otherProps }) => {
+const Slider = ({ onChange, labelsMask, className, ...otherProps }) => {
   const { min, max, value: propValue } = otherProps
 
   const [stateValue, setStateValue] = React.useState(propValue || min)
@@ -21,8 +22,9 @@ const Slider = ({ onChange, labelsMask, ...otherProps }) => {
   const value = propValue || stateValue
   const showSlider = hover || focus
 
+  const classNames = cx('orion-slider-wrapper', className)
   return (
-    <div className="orion-slider-wrapper">
+    <div className={classNames}>
       <input
         type="range"
         className="orion-slider"
@@ -56,6 +58,7 @@ Slider.defaultProps = {
 }
 
 Slider.propTypes = {
+  className: PropTypes.string,
   labelsMask: PropTypes.func,
   max: PropTypes.number,
   min: PropTypes.number,


### PR DESCRIPTION
Notei que quando passava um `className` para o componente de slider, ele perdia os estilos padrões porque o `className` era sobrescrito.

Este PR resolve isso:

Exemplo de customização de cor do track:

![image](https://user-images.githubusercontent.com/1139664/73405999-246f5f00-42d4-11ea-8e1c-bd8e46f908a7.png)
