### PR TITLE
feature(dropdown-label): Truncate dropdown and label text

### DIFF
--- a/packages/orion/src/Dropdown/Dropdown.test.js
+++ b/packages/orion/src/Dropdown/Dropdown.test.js
@@ -42,7 +42,7 @@ describe('when an option is selected', () => {
 
     const [label] = getAllByText('Red')
     expect(label).toBeTruthy()
-    expect(label).toHaveClass('orion label')
+    expect(label.closest('.orion.label')).toBeTruthy()
   })
 
   it('should show option on the list, as selected', () => {

--- a/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
+++ b/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
@@ -1,5 +1,5 @@
 .orion.dropdown .menu > .item .text {
-  @apply leading-20 truncate;
+  @apply leading-20;
 }
 
 .orion.dropdown .menu > .item,

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -23,7 +23,11 @@
 }
 
 .orion.dropdown .text {
-  @apply text-gray-900 z-10;
+  @apply text-gray-900 truncate z-10;
+}
+
+.orion.dropdown > .text {
+  @apply flex-1;
 }
 
 .orion.dropdown .text.default {

--- a/packages/orion/src/Label/index.js
+++ b/packages/orion/src/Label/index.js
@@ -21,7 +21,7 @@ const Label = ({
         <div className="label-remove" onClick={e => onRemove(e, otherProps)}>
           <Icon name="clear" size="big" />
         </div>
-        {children || content}
+        <div className="label-text">{children || content}</div>
       </React.Fragment>
     )
   }

--- a/packages/orion/src/Label/label.css
+++ b/packages/orion/src/Label/label.css
@@ -1,5 +1,5 @@
 .orion.label {
-  @apply inline-flex items-center px-8 bg-gray-900-8 rounded leading-20 text-gray-900 h-32;
+  @apply inline-flex items-center px-8 bg-gray-900-8 rounded leading-20 text-gray-900 truncate h-32;
 }
 
 .orion.label.small {
@@ -28,4 +28,8 @@
 .orion.label.small .label-remove {
   @apply rounded-r-none;
   margin-left: -8px;
+}
+
+.label-text {
+  @apply truncate;
 }

--- a/packages/orion/src/Slider/Slider.test.js
+++ b/packages/orion/src/Slider/Slider.test.js
@@ -4,11 +4,8 @@ import { render } from '@testing-library/react'
 import Slider from './'
 
 it('should show popup if slider is focused', () => {
-  const { queryByText, queryByDisplayValue, debug } = render(
-    <Slider value={30} />
-  )
+  const { queryByText, queryByDisplayValue } = render(<Slider value={30} />)
 
-  console.log(debug())
   queryByDisplayValue('30').focus()
   expect(queryByText('30')).toBeVisible()
 })


### PR DESCRIPTION
Textos grandes estavam saindo pra fora dos componentes. Passei a truncar por default.

**Antes**
<img width="274" alt="Screen Shot 2020-02-04 at 2 20 50 PM" src="https://user-images.githubusercontent.com/5216049/73770174-b9ea7300-475a-11ea-8895-b14f5d27b73e.png">

**Depois**
<img width="279" alt="Screen Shot 2020-02-04 at 2 21 02 PM" src="https://user-images.githubusercontent.com/5216049/73770175-ba830980-475a-11ea-8528-7e7b90eaa7e8.png">

**Antes (multiple)**
<img width="273" alt="Screen Shot 2020-02-04 at 2 25 10 PM" src="https://user-images.githubusercontent.com/5216049/73770179-ba830980-475a-11ea-9b4d-57357875e02f.png">

**Depois (multiple)**
<img width="278" alt="Screen Shot 2020-02-04 at 2 24 57 PM" src="https://user-images.githubusercontent.com/5216049/73770178-ba830980-475a-11ea-9663-feef53926277.png">
