### PR TITLE
fix(icon): Fix some Icon CSS rules not being applied

### DIFF
--- a/packages/orion/src/Icon/index.js
+++ b/packages/orion/src/Icon/index.js
@@ -9,7 +9,7 @@ import { createShorthandFactory } from '../utils/factories'
 const Icon = ({ as: AsElementType, className, color, name, ...otherProps }) => {
   const isCustomIcon = !!CUSTOM_ICONS_MAP[name] || !!AsElementType
   const ElementType = AsElementType || CUSTOM_ICONS_MAP[name] || 'i'
-  const classes = cx(className, 'icon', {
+  const classes = cx(className, 'orion icon', {
     'material-icons': !isCustomIcon,
     [`text-${color}`]: !isCustomIcon && color,
     [`fill-${color}`]: isCustomIcon && color


### PR DESCRIPTION
Eu fiz um pr deixando as regras CSS do `Icon` mais específicas pra o **Orion**, pra não entrar em conflito com outras libs (como o **Supernova**).

Isso funcionou perfeito pra o ícone especial de **loading**, que é um ícone especial. Mas pra os ícones normais eu acabei quebrando uma regra que existia, porque o semantic não adiciona o prefixo do projeto (que no nosso caso é **orion**) pra `Icon`, só para todos os outros componentes. Aí uma regra que eu deixei mais específica (de `i.icon` para `i.orion.icon`), que definia o tamanho da fonte, parou de pegar.

Ajeitei aqui adicionando eu mesma o prefixo, pra podermos ter essas regras mais específicas funcionando.

**Antes (estava pegando fonte 24px do material icons)**
<img width="228" alt="Screen Shot 2020-02-07 at 11 26 38 AM" src="https://user-images.githubusercontent.com/5216049/74037312-c3fbb400-499c-11ea-8fc4-1a4487042586.png">

**Depois (com os nossos 20px default)**
<img width="259" alt="Screen Shot 2020-02-07 at 11 25 10 AM" src="https://user-images.githubusercontent.com/5216049/74037309-c2ca8700-499c-11ea-8880-65ff4ae5115f.png">

