### PR TITLE
fix(firefox): Fix overflow on Firefox

### DIFF
--- a/packages/orion/src/Slider/slider.css
+++ b/packages/orion/src/Slider/slider.css
@@ -13,6 +13,12 @@ input[type='range'].orion-slider {
   padding: 0 1px;
 }
 
+@supports (-moz-appearance: none) {
+  input[type='range'].orion-slider {
+    @apply overflow-visible p-0;
+  }
+}
+
 /* focus */
 input[type='range'].orion-slider:focus {
   @apply outline-none;


### PR DESCRIPTION
Quando o slider está focado, ele adiciona um shadow no `thumb` do slider.

O container do Slider tem um `overflow: hidden` porque a gente tá usando uma técnica de shadow "pintar" o `track` de outra cor do lado esquerdo (apenas no Chrome).

Para que a parte do shadow do track não ficasse hidden quando ele estivesse em algumas das pontas (olhar imagem), eu adicionei um padding de `1px` para os lados. Esta solução funcionou bem no Chrome, mas não no Firefox, que não usa a gambiarra mencionada acima.

Então adicionei um css que só funciona no Firefox, e resolve o problema que só acontece no firefox:

Antes:
![image](https://user-images.githubusercontent.com/1139664/74048287-b3edcf80-49b0-11ea-868d-6df8cba3dc7f.png)

Depois:
![image](https://user-images.githubusercontent.com/1139664/74048320-c0722800-49b0-11ea-803b-cadc793fc545.png)


