### PR TITLE
fix(button): Fix alignment of buttons with icons

### DIFF
--- a/packages/orion/src/Button/button.css
+++ b/packages/orion/src/Button/button.css
@@ -16,6 +16,8 @@
 .orion.button:not(.icon) > .icon {
   @apply flex justify-center;
   @apply h-24 w-24;
+  @apply mr-2;
+  margin-left: -5px;
   vertical-align: sub;
 }
 


### PR DESCRIPTION
Nossos botões ficavam esquisitos com ícones, devido ao espaçamento interno do ícone. Ajustei o alinhamento pra ficar melhor.

**Antes**
<img width="148" alt="Screen Shot 2020-02-07 at 2 29 23 PM" src="https://user-images.githubusercontent.com/5216049/74053494-ae958280-49ba-11ea-9c96-3049db0c0950.png">

**Depois**
<img width="142" alt="Screen Shot 2020-02-07 at 2 30 30 PM" src="https://user-images.githubusercontent.com/5216049/74053495-af2e1900-49ba-11ea-8cff-0271a900351d.png">

