### PR TITLE
fix(InfoIcon): Fix InfoIcon's size

### DIFF
--- a/packages/orion/src/InfoIcon/infoIcon.css
+++ b/packages/orion/src/InfoIcon/infoIcon.css
@@ -1,4 +1,4 @@
-.icon.info-icon {
+.orion.icon.info-icon {
   @apply cursor-default select-none text-gray-600;
   font-size: 16px;
 }


### PR DESCRIPTION
Aquele `.orion` que eu acrescentei nas regras do `Icon` pra torná-las mais específicas quebrou o tamanho do `InfoIcon`, que ficou menos específico do que as regras default agora.

Ajeitei e verifiquei todos os componentes do Orion pra ver se mais algum tinha sido afetado, mas esse parece ter sido o único mesmo (🙏).

**Antes**
<img width="160" alt="Screen Shot 2020-02-10 at 9 07 13 AM" src="https://user-images.githubusercontent.com/5216049/74149282-298eb100-4be6-11ea-8e28-8ea948f21b0e.png">

**Depois**
<img width="126" alt="Screen Shot 2020-02-10 at 9 07 17 AM" src="https://user-images.githubusercontent.com/5216049/74149289-2abfde00-4be6-11ea-8c8c-2a2c60cec4f1.png">

