### PR TITLE
fix(popup): Fix line-height of popup contents

### DIFF
--- a/packages/orion/src/Popup/popup.css
+++ b/packages/orion/src/Popup/popup.css
@@ -1,5 +1,5 @@
 .orion.popup {
-  @apply bg-white border border-gray-900-8 leading-14 max-w-384 p-16 rounded shadow-300 text-gray-800 z-50;
+  @apply bg-white border border-gray-900-8 leading-20 max-w-384 p-16 rounded shadow-300 text-gray-800 z-50;
 }
 
 .orion.popup:before {


### PR DESCRIPTION
Notei que quando havia mais de uma linha na nossa **Popup** ela ficava esquisita, com uma linha do texto muito próxima da outra. O line height estava errado, pra texto com tamanho **14px** queremos usar line height de **20px**.

**Antes**
<img width="418" alt="Screen Shot 2020-02-11 at 3 15 54 PM" src="https://user-images.githubusercontent.com/5216049/74268169-267aea00-4ce6-11ea-8f6d-540ffa75924e.png">

**Depois**
<img width="419" alt="Screen Shot 2020-02-11 at 3 15 42 PM" src="https://user-images.githubusercontent.com/5216049/74268165-24b12680-4ce6-11ea-83f1-38e9a2ab8281.png">