### PR TITLE
fix(checkbox): Fix checkbox without label and disabled cursor

### DIFF
--- a/packages/orion/src/Checkbox/Checkbox.stories.js
+++ b/packages/orion/src/Checkbox/Checkbox.stories.js
@@ -11,7 +11,7 @@ export default {
 export const regular = () => (
   <React.Fragment>
     <Checkbox
-      label={!boolean('No label', false) && text('Label', 'Click Me')}
+      label={boolean('No label', false) ? null : text('Label', 'Click Me')}
       defaultChecked
       indeterminate={boolean('Indeterminate', false)}
       disabled={boolean('Disabled', false)}

--- a/packages/orion/src/Checkbox/checkbox.css
+++ b/packages/orion/src/Checkbox/checkbox.css
@@ -1,5 +1,5 @@
 .orion.checkbox {
-  @apply my-2 relative h-16;
+  @apply my-2 relative min-h-16;
 }
 
 .orion.checkbox input[type='checkbox'] {
@@ -8,7 +8,11 @@
   @apply block !important;
 }
 
-.orion.checkbox.fitted > label {
+.orion.checkbox.fitted {
+  @apply min-w-16;
+}
+
+.orion.checkbox.fitted input[type='checkbox'] ~ label {
   @apply pl-0;
 }
 
@@ -37,27 +41,15 @@
   @apply bg-wave-500;
 }
 
-.orion.checkbox:not(.disabled)
-  input[type='checkbox']:checked
-  ~ label:hover:before,
-.orion.checkbox:not(.disabled)
-  input[type='checkbox']:indeterminate
-  ~ label:hover:before {
+.orion.checkbox input[type='checkbox']:checked ~ label:hover:before,
+.orion.checkbox input[type='checkbox']:indeterminate ~ label:hover:before {
   @apply bg-wave-600;
 }
 
-.orion.checkbox:not(.disabled)
-  input[type='checkbox']:checked
-  ~ label:active:before,
-.orion.checkbox:not(.disabled)
-  input[type='checkbox']:indeterminate
-  ~ label:active:before,
-.orion.checkbox:not(.disabled)
-  input[type='checkbox']:checked:focus
-  ~ label:before,
-.orion.checkbox:not(.disabled)
-  input[type='checkbox']:indeterminate:focus
-  ~ label:before {
+.orion.checkbox input[type='checkbox']:checked ~ label:active:before,
+.orion.checkbox input[type='checkbox']:indeterminate ~ label:active:before,
+.orion.checkbox input[type='checkbox']:checked:focus ~ label:before,
+.orion.checkbox input[type='checkbox']:indeterminate:focus ~ label:before {
   @apply bg-wave-700;
 }
 
@@ -79,6 +71,10 @@
 /**
  * Disabled
  */
+
+.orion.checkbox.disabled {
+  pointer-events: none;
+}
 
 .orion.checkbox.disabled input[type='checkbox'] ~ label {
   @apply text-gray-800;


### PR DESCRIPTION
Esse pr traz 3 fixes para o **Checkbox**:

1. O cursor quando o checkbox estava disabled era o **pointer**. Passou agora a ser o **default**.
2. Quando não havia label estávamos deixando o checkbox com uma margenzinha à direita, como se fosse o espaçamento para a label inexistente. Isso faz ele tomar mais espaço do que o que deveria e atrapalha alinhamentos. Era um bug nas regras CSS que um dia funcionaram pra isso, mas falharam quando outras ficaram mais específicas.

**Antes**
<img width="293" alt="Screen Shot 2020-02-12 at 2 12 53 PM" src="https://user-images.githubusercontent.com/5216049/74362177-fb0c0400-4da6-11ea-885c-5aec9f6e629c.png">

**Depois**
<img width="306" alt="Screen Shot 2020-02-12 at 2 12 42 PM" src="https://user-images.githubusercontent.com/5216049/74362170-f9424080-4da6-11ea-9c9e-21ccc3ef4022.png">

3. Quando a label ocupava mais de uma linha, o height do checkbox continuava sendo `16px` mesmo com um conteúdo maior. Ajustei a regra pra definir min height no lugar de height.

**Antes**
<img width="333" alt="Screen Shot 2020-02-12 at 2 58 21 PM" src="https://user-images.githubusercontent.com/5216049/74362910-44a91e80-4da8-11ea-8a7d-ffdedaca3916.png">

**Depois**
<img width="326" alt="Screen Shot 2020-02-12 at 2 58 28 PM" src="https://user-images.githubusercontent.com/5216049/74362911-45da4b80-4da8-11ea-8baa-02aa9900f4eb.png">
