### PR TITLE
fix(input): Fix input height/width not matching the component's height/width

### DIFF
--- a/packages/orion/src/Input/input.css
+++ b/packages/orion/src/Input/input.css
@@ -1,8 +1,9 @@
 .orion.input {
-  @apply inline-flex relative;
+  @apply h-48 inline-flex relative;
+  width: 256px;
 }
 .orion.input > input {
-  @apply h-48 pl-16 flex justify-center outline-none;
+  @apply h-full pl-16 flex justify-center outline-none w-full;
 }
 
 .orion.input:not(.labeled) > input {
@@ -27,7 +28,7 @@
   @apply h-em w-em;
 }
 
-.orion.input.small > input {
+.orion.input.small {
   @apply h-32;
 }
 
@@ -59,7 +60,7 @@
   @apply shadow-warning-field-active;
 }
 
-.orion.input.fluid > input {
+.orion.input.fluid {
   @apply w-full;
 }
 


### PR DESCRIPTION
Setar um width ou height no **Input** no **Orion** não estava funcionando. O componente se comportava de uma forma esquisita em ambos os casos. Corrigi os dois aqui.

**Antes (com custom width)**
<img width="323" alt="Screen Shot 2020-02-13 at 4 32 23 PM" src="https://user-images.githubusercontent.com/5216049/74471411-ed29b200-4e7e-11ea-8be0-84f4c06c2cd1.png">

**Depois (com custom width)**
<img width="319" alt="Screen Shot 2020-02-13 at 4 32 27 PM" src="https://user-images.githubusercontent.com/5216049/74471420-ef8c0c00-4e7e-11ea-9a07-1ddf26767a58.png">

**Antes (com custom height)**
<img width="313" alt="Screen Shot 2020-02-13 at 4 34 25 PM" src="https://user-images.githubusercontent.com/5216049/74471425-f0bd3900-4e7e-11ea-8d42-15f5b4cde2b6.png">

**Depois (com custom height)**
<img width="318" alt="Screen Shot 2020-02-13 at 4 34 29 PM" src="https://user-images.githubusercontent.com/5216049/74471430-f155cf80-4e7e-11ea-8260-6695e3eb01ae.png">
