### PR TITLE
fix(input): Forward refs to the input component

### DIFF
--- a/packages/orion/src/Input/index.js
+++ b/packages/orion/src/Input/index.js
@@ -6,14 +6,16 @@ import { Input as SemanticInput } from '@inloco/semantic-ui-react'
 import { createShorthandFactory } from '../utils/factories'
 import { Sizes, sizePropType } from '../utils/sizes'
 
-const Input = ({ className, warning, size, ...otherProps }) => {
-  const { fluid } = otherProps
-  const classes = cx(className, size, {
-    warning,
-    'w-full': fluid
-  })
-  return <SemanticInput className={classes} {...otherProps} />
-}
+const Input = React.forwardRef(
+  ({ className, warning, size, ...otherProps }, ref) => {
+    const { fluid } = otherProps
+    const classes = cx(className, size, {
+      warning,
+      'w-full': fluid
+    })
+    return <SemanticInput className={classes} ref={ref} {...otherProps} />
+  }
+)
 
 Input.propTypes = {
   className: PropTypes.string,

--- a/packages/orion/src/utils/factories.js
+++ b/packages/orion/src/utils/factories.js
@@ -22,9 +22,6 @@ import React, { cloneElement, isValidElement } from 'react'
  * @returns {object|null}
  */
 export function createShorthand(Component, mapValueToProps, val, options = {}) {
-  if (typeof Component !== 'function' && typeof Component !== 'string') {
-    throw new Error('createShorthand() Component must be a string or function.')
-  }
   // short circuit noop values
   if (_.isNil(val) || _.isBoolean(val)) return null
 
@@ -146,12 +143,6 @@ export function createShorthand(Component, mapValueToProps, val, options = {}) {
  * @returns {function} A shorthand factory function waiting for `val` and `defaultProps`.
  */
 export function createShorthandFactory(Component, mapValueToProps) {
-  if (typeof Component !== 'function' && typeof Component !== 'string') {
-    throw new Error(
-      'createShorthandFactory() Component must be a string or function.'
-    )
-  }
-
   return (val, options) =>
     createShorthand(Component, mapValueToProps, val, options)
 }


### PR DESCRIPTION
De vez em quando caio nesse problema: algum componente precisa usar refs em um componente do **Orion** e não funciona porque usamos functional components.

Dessa vez foi o **Input**, aí adicionei o `forwardRef` nele pra pegar direitinho.

Mas depois talvez valha a pena ir de componente em componente adicionando em todos, e deixar na doc um guideline pra gente sempre criar novos componentes já com isso por default.