### PR TITLE
Feature/dimmed top bar

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -191,7 +191,7 @@ module.exports = {
           .string()
       },
       space: {
-        ..._.pick(theme('colors.space'), ['600', '900']),
+        ..._.pick(theme('colors.space'), ['600']),
         '900-8': Color(theme('colors').space['900'])
           .alpha(0.08)
           .string()

--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -190,7 +190,12 @@ module.exports = {
           .alpha(0.24)
           .string()
       },
-      space: _.pick(theme('colors.space'), ['600']),
+      space: {
+        ..._.pick(theme('colors.space'), ['600', '900']),
+        '900-8': Color(theme('colors').space['900'])
+          .alpha(0.08)
+          .string()
+      },
       wave: _.pick(theme('colors.wave'), ['200', '500', '600', '700']),
       green: _.pick(theme('colors.green'), ['500']),
       yellow: _.pick(theme('colors.yellow'), ['500']),

--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import { loremIpsum } from 'lorem-ipsum'
 import React from 'react'
-import { object, withKnobs } from '@storybook/addon-knobs'
+import { boolean, object, withKnobs } from '@storybook/addon-knobs'
 
 import { Dropdown, Layout, Menu } from '../'
 
@@ -12,7 +12,7 @@ export default {
 
 export const basic = () => (
   <Layout className="absolute left-0 top-0 w-full">
-    <Layout.Topbar>
+    <Layout.Topbar dimmed={boolean('Dimmed Topbar')}>
       <Menu
         items={object('Items', [
           { name: 'Onboarding', key: 0 },
@@ -30,7 +30,10 @@ export const basic = () => (
       <Dropdown
         className="ml-auto"
         text="Maira Bello"
-        options={[{ text: 'Account', value: 1 }, { text: 'Logout', value: 2 }]}
+        options={[
+          { text: 'Account', value: 1 },
+          { text: 'Logout', value: 2 }
+        ]}
         compact
         size="small"
       />

--- a/packages/orion/src/Layout/LayoutTopbar/index.js
+++ b/packages/orion/src/Layout/LayoutTopbar/index.js
@@ -18,7 +18,8 @@ const LayoutTopbar = ({ className, children, logo, dimmed, ...otherProps }) => {
 LayoutTopbar.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
-  logo: PropTypes.node
+  logo: PropTypes.node,
+  dimmed: PropTypes.bool
 }
 
 export default LayoutTopbar

--- a/packages/orion/src/Layout/LayoutTopbar/index.js
+++ b/packages/orion/src/Layout/LayoutTopbar/index.js
@@ -5,8 +5,8 @@ import React from 'react'
 import LayoutCenter from '../LayoutCenter'
 import Logo from '../../Logo'
 
-const LayoutTopbar = ({ className, children, logo, ...otherProps }) => {
-  const classes = cx('layout-topbar', className)
+const LayoutTopbar = ({ className, children, logo, dimmed, ...otherProps }) => {
+  const classes = cx('layout-topbar', { dimmed }, className)
   return (
     <LayoutCenter className={classes} {...otherProps}>
       {logo || <Logo className="mb-4" />}

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -16,6 +16,10 @@
   @apply border-b-1 border-gray-900-16;
 }
 
+.orion.layout .layout-topbar.dimmed {
+  @apply bg-gray-100 border-space-900-8;
+}
+
 .orion.layout .layout-topbar > .layout-center-content {
   @apply flex items-center;
 }


### PR DESCRIPTION
Victinho adicionou no protótipo da navegação global a opção de termos o Topbar do layout escurecido na tela da Cloud, para deviar o foco para as opções de produtos.
Então estou adicionando uma prop `dimmed` na Topbar que muda as cores para as definidas no protótipo.

Protótipo
![Screen Shot 2020-02-14 at 12 51 25](https://user-images.githubusercontent.com/9112403/74546065-bc05bc00-4f28-11ea-8ea7-0ec76e58034f.png)


Sem `dimmed`
![Screen Shot 2020-02-14 at 12 49 10](https://user-images.githubusercontent.com/9112403/74546002-9d9fc080-4f28-11ea-9702-11fb552183bd.png)


Com `dimmed`
![Screen Shot 2020-02-14 at 12 49 16](https://user-images.githubusercontent.com/9112403/74546014-a1cbde00-4f28-11ea-9d91-1bb011f7bb64.png)
