### PR TITLE
feature(input): Style labeled inputs

### DIFF
--- a/packages/orion/src/Input/Input.stories.js
+++ b/packages/orion/src/Input/Input.stories.js
@@ -10,16 +10,13 @@ export default {
 }
 
 export const defaultStory = () => {
-  const error = boolean('error', false)
-  const warning = boolean('warning', false)
-  const disabled = boolean('disabled', false)
   return (
     <Input
-      placeholder="Input placeholder"
-      warning={warning}
-      error={error}
+      placeholder={text('Placeholder', 'Type here')}
       size={sizeKnob()}
-      disabled={disabled}
+      error={boolean('error', false)}
+      warning={boolean('warning', false)}
+      disabled={boolean('disabled', false)}
       fluid={boolean('fluid', false)}
       icon={text('Icon')}
     />
@@ -28,4 +25,19 @@ export const defaultStory = () => {
 
 defaultStory.story = {
   name: 'default'
+}
+
+export const labeled = () => {
+  return (
+    <Input
+      label={text('Label', 'https://')}
+      placeholder={text('Placeholder', 'Type an URL')}
+      size={sizeKnob()}
+      error={boolean('error', false)}
+      warning={boolean('warning', false)}
+      disabled={boolean('disabled', false)}
+      fluid={boolean('fluid', false)}
+      icon={text('Icon')}
+    />
+  )
 }

--- a/packages/orion/src/Input/input.css
+++ b/packages/orion/src/Input/input.css
@@ -4,9 +4,6 @@
 }
 .orion.input > input {
   @apply h-full pl-16 flex justify-center outline-none w-full;
-}
-
-.orion.input:not(.labeled) > input {
   @apply bg-white border border-solid border-gray-900-24 rounded;
 }
 
@@ -74,4 +71,30 @@
 
 .orion.input.icon > input ~ .icon {
   @apply absolute right-0 w-40 h-full flex items-center justify-center;
+}
+
+/** Labeled **/
+
+.orion.input.labeled {
+  @apply bg-white border border-solid border-gray-900-24 rounded;
+}
+
+.orion.input.labeled > .label {
+  @apply h-full flex-shrink-0 rounded-none text-gray-700;
+}
+
+.orion.input.labeled > input {
+  @apply bg-transparent border-none flex-1 rounded-none;
+}
+
+.orion.input.labeled.error {
+  @apply border-magenta-500;
+}
+
+.orion.input.labeled.warning {
+  @apply border-yellow-500;
+}
+
+.orion.input.labeled.disabled {
+  @apply bg-gray-900-8;
 }


### PR DESCRIPTION
O **Input** com label faltava ser estilizado, por enquanto ficava bem esquisito. Ajeitei aqui.

**Antes**
<img width="272" alt="Screen Shot 2020-02-14 at 2 27 49 PM" src="https://user-images.githubusercontent.com/5216049/74553498-456fbb00-4f36-11ea-9976-c1cc88a08377.png">

**Depois**
<img width="281" alt="Screen Shot 2020-02-14 at 2 22 58 PM" src="https://user-images.githubusercontent.com/5216049/74553395-0b9eb480-4f36-11ea-866b-8bb4193985c9.png">
