### PR TITLE
fix(search): Fix Search width

### DIFF
--- a/packages/orion/src/Search/Search.stories.js
+++ b/packages/orion/src/Search/Search.stories.js
@@ -25,6 +25,7 @@ export const basic = () => {
       error={boolean('Error', false)}
       warning={boolean('Warning', false)}
       loading={boolean('Loading', false)}
+      fluid={boolean('Fluid', false)}
     />
   )
 }

--- a/packages/orion/src/Search/search.css
+++ b/packages/orion/src/Search/search.css
@@ -1,13 +1,18 @@
 .orion.search {
   @apply relative inline-block h-48;
+  min-width: 256px;
 }
 
 .orion.search.small {
   @apply h-32;
 }
 
+.orion.search.fluid {
+  @apply w-full;
+}
+
 .orion.search > .orion.input {
-  @apply h-full;
+  @apply h-full w-full;
 }
 
 .orion.search > .orion.input > input {


### PR DESCRIPTION
Haviam 2 problemas com o width do componente **Search**:

1. Se o width do componente fosse setado, o input interno dele não acompanhava esse width, parecendo que nada foi feito:

**Antes**
<img width="435" alt="Screen Shot 2020-02-14 at 2 44 53 PM" src="https://user-images.githubusercontent.com/5216049/74554676-db0c4a00-4f38-11ea-9e18-21b94dbcb12b.png">

**Depois**
<img width="446" alt="Screen Shot 2020-02-14 at 2 45 04 PM" src="https://user-images.githubusercontent.com/5216049/74554679-dcd60d80-4f38-11ea-9742-f796476299fb.png">

2. A prop **fluid** não estava fazendo nada. https://github.com/inloco/orion/issues/433

**Antes (com fluid)**
<img width="860" alt="Screen Shot 2020-02-14 at 2 44 34 PM" src="https://user-images.githubusercontent.com/5216049/74554719-f24b3780-4f38-11ea-82ae-e3cba46df221.png">

**Depois (com fluid)**
<img width="864" alt="Screen Shot 2020-02-14 at 2 44 31 PM" src="https://user-images.githubusercontent.com/5216049/74554718-f11a0a80-4f38-11ea-8184-da86add5ae2f.png">

