### PR TITLE
fix(form): Fix dropdown items height inside forms

### DIFF
--- a/packages/orion/src/Form/Field/field.css
+++ b/packages/orion/src/Form/Field/field.css
@@ -15,7 +15,7 @@
   @apply mt-8 text-sm;
 }
 
-.orion.form .field.floatingLabel .dropdown .text,
+.orion.form .field.floatingLabel .dropdown > .text,
 .orion.form .field.floatingLabel input {
   @apply pt-16;
 }


### PR DESCRIPTION
A altura dos itens do dropdown estava maior quando o dropdown estava dentro de um form. Era só uma regrinha de CSS que estava afetando os elementos `.text` dentro de cada item, mas deveria afetar apenas o `.text` que fica diretamente dentro do dropdown. Deixei a regra mais específica pra corrigir.

**Antes**
<img width="285" alt="Screen Shot 2020-02-18 at 2 53 37 PM" src="https://user-images.githubusercontent.com/5216049/74763998-9f86be00-525f-11ea-8769-99993c9eae8d.png">

**Depois**
<img width="299" alt="Screen Shot 2020-02-18 at 2 53 20 PM" src="https://user-images.githubusercontent.com/5216049/74763992-9d246400-525f-11ea-98b3-cf1e655e4552.png">