### PR TITLE
feature(field): Allow fields to be inline

### DIFF
--- a/packages/orion/src/Form/Field/field.css
+++ b/packages/orion/src/Form/Field/field.css
@@ -2,9 +2,14 @@
   @apply relative;
 }
 
+.orion.form .field > label,
+.orion.form .fields > label {
+  @apply block mb-8;
+}
+
 /* Floated label */
 .orion.form .field.floatingLabel label {
-  @apply absolute border-l-1 top-0 block .cursor-text ml-16 text-gray-800 text-base transition-default z-10;
+  @apply absolute border-l-1 top-0 block .cursor-text ml-16 pb-0 text-gray-800 text-base transition-default z-10;
   transition-property: margin-top, font-size;
   border-color: transparent !important;
   margin-top: 17px;
@@ -54,4 +59,19 @@
 
 .orion-form-field__message--warning {
   @apply text-yellow-500;
+}
+
+/* Inline */
+
+.orion.form .fields.inline {
+  @apply flex !important;
+  @apply flex-wrap items-center;
+}
+
+.orion.form .fields.inline > label {
+  @apply w-full;
+}
+
+.orion.form .fields.inline > .field {
+  @apply mr-16;
 }

--- a/packages/orion/src/Form/Form.stories.js
+++ b/packages/orion/src/Form/Form.stories.js
@@ -84,3 +84,16 @@ export const formShorthands = () => (
     </Button>
   </Form>
 )
+
+export const checkboxes = () => {
+  return (
+    <Form>
+      <Form.Group inline={boolean('Inline', false)}>
+        <label>Job</label>
+        <Form.Checkbox label="Backend Engineer" />
+        <Form.Checkbox label="Frontend Engineer" />
+        <Form.Checkbox label="Mobile Engineer" />
+      </Form.Group>
+    </Form>
+  )
+}


### PR DESCRIPTION
Em alguns casos queremos os nossos fields inline com a label. Existe um `Form.Group` que ajuda com isso no semantic, mas faltava implementar um CSS **inline** pra ele.

**Normal**
<img width="175" alt="Screen Shot 2020-02-18 at 4 48 20 PM" src="https://user-images.githubusercontent.com/5216049/74772587-0cee1b00-526f-11ea-9740-e25644fca745.png">

**Inline**
<img width="640" alt="Screen Shot 2020-02-18 at 5 02 09 PM" src="https://user-images.githubusercontent.com/5216049/74773359-7d496c00-5270-11ea-870a-c0c3a4b6b32f.png">

P.S.: Garanti que isso não está afetando as floating labels.
