### PR TITLE
feature(datepicker): Allow passing props to the picker's popup

### DIFF
--- a/packages/orion/src/Datepicker/datepicker.css
+++ b/packages/orion/src/Datepicker/datepicker.css
@@ -34,7 +34,7 @@
 }
 
 .DayPicker_weekHeader_ul {
-  @apply flex;
+  @apply flex m-0;
 }
 
 .DayPicker_weekHeader_li {

--- a/packages/orion/src/DatepickerInput/DatepickerInput.stories.js
+++ b/packages/orion/src/DatepickerInput/DatepickerInput.stories.js
@@ -22,6 +22,9 @@ export const basic = () => (
     warning={boolean('warning', false)}
     disabled={boolean('disabled', false)}
     fluid={boolean('fluid', false)}
+    popupProps={{
+      position: text('Popup position', 'bottom left')
+    }}
     {...actions}
   />
 )

--- a/packages/orion/src/DatepickerInput/SharedInput/index.js
+++ b/packages/orion/src/DatepickerInput/SharedInput/index.js
@@ -10,6 +10,7 @@ const DatepickerSharedInput = ({
   disabled,
   onChange,
   picker,
+  popupProps,
   value,
   ...otherProps
 }) => {
@@ -43,6 +44,8 @@ const DatepickerSharedInput = ({
         </div>
       }
       content={picker}
+      position="bottom left"
+      {...popupProps}
     />
   )
 }
@@ -52,7 +55,12 @@ DatepickerSharedInput.propTypes = {
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
   picker: PropTypes.node.isRequired,
+  popupProps: PropTypes.object,
   value: PropTypes.string
+}
+
+DatepickerSharedInput.defaultProps = {
+  popupProps: {}
 }
 
 export default DatepickerSharedInput

--- a/packages/orion/src/DatepickerInput/datepickerInput.css
+++ b/packages/orion/src/DatepickerInput/datepickerInput.css
@@ -2,6 +2,10 @@
   @apply cursor-pointer text-gray-700;
 }
 
+.datepicker-input-trigger {
+  width: fit-content;
+}
+
 .datepicker-input-trigger.disabled {
   @apply pointer-events-none;
 }


### PR DESCRIPTION
Não tinha como passar props para a popup do novo **DatepickerInput**, então adicionei essa opção agora com a prop **popupProps**.

O principal caso de uso que me fez notar isso era a posição da popup, então aproveitei pra adicionar uma knob no storybook pra testar essa opção.

**Bottom left (default)**
<img width="346" alt="Screen Shot 2020-02-20 at 9 30 56 AM" src="https://user-images.githubusercontent.com/5216049/74933984-fb6a5780-53c3-11ea-93e9-90c38badaa3d.png">

**Bottom right**
<img width="361" alt="Screen Shot 2020-02-20 at 9 31 02 AM" src="https://user-images.githubusercontent.com/5216049/74933990-fd341b00-53c3-11ea-8b61-16de4126ed27.png">
