### PR TITLE
chore(datepicker): Get rid of warning from "moment"

### DIFF
--- a/packages/orion/src/DatepickerInput/index.js
+++ b/packages/orion/src/DatepickerInput/index.js
@@ -23,7 +23,7 @@ const DatepickerInput = ({
 
   const handleInputChange = (event, { value }) => {
     setInputValue(value)
-    onChange && onChange(event, { value: toMoment(value) })
+    onChange && onChange(event, { value: toMoment(value, displayFormat) })
   }
   const handlePickerChange = momentDate => {
     const inputValue = formatDate(momentDate, displayFormat)
@@ -47,7 +47,7 @@ const DatepickerInput = ({
         <Datepicker
           {...pickerProps}
           defaultDate={defaultValue}
-          date={value}
+          date={toMoment(value, displayFormat)}
           onDateChange={handlePickerChange}
         />
       }

--- a/packages/orion/src/DatepickerInput/utils.js
+++ b/packages/orion/src/DatepickerInput/utils.js
@@ -1,7 +1,7 @@
 import { toMoment } from '../utils/datetime'
 
 export const formatDate = (date, displayFormat) => {
-  const momentDate = toMoment(date)
+  const momentDate = toMoment(date, displayFormat)
   return momentDate && momentDate.isValid()
     ? momentDate.format(displayFormat)
     : null

--- a/packages/orion/src/RangedDatepickerInput/index.js
+++ b/packages/orion/src/RangedDatepickerInput/index.js
@@ -33,7 +33,7 @@ const RangedDatepickerInput = ({
   )
 
   const toMomentIfKnown = date =>
-    date === UNKNOWN_DATE ? null : toMoment(date)
+    date === UNKNOWN_DATE ? null : toMoment(date, displayFormat)
   const toDatesObject = datesStr => {
     const [startDateStr, endDateStr] = (datesStr || '').split(SEPARATOR)
     return startDateStr || endDateStr

--- a/packages/orion/src/utils/datetime.js
+++ b/packages/orion/src/utils/datetime.js
@@ -1,3 +1,3 @@
 import moment from 'moment'
 
-export const toMoment = date => date && moment(date)
+export const toMoment = (date, format) => date && moment(date, format)


### PR DESCRIPTION
Notei que o **moment** estava lançando warnings no console quando uma data era selecionada no novo **DatepickerInput**:

<img width="1440" alt="Screen Shot 2020-02-20 at 10 28 10 AM" src="https://user-images.githubusercontent.com/5216049/74937926-d548b580-53cb-11ea-87bc-301859c80a28.png">

Pelo visto o **moment** não suporta o formato que estamos usando para as datas (MM/DD/YYYY) automaticamente. Pra aceitá-lo ele tem que receber diretamente o formato sendo usado ao converter para o moment. Então foi o que fiz e o warning sumiu.