### PR TITLE
chore(RangedDatepickerInput): Split the ranged datepicker input into two

### DIFF
--- a/packages/orion/components.css
+++ b/packages/orion/components.css
@@ -28,6 +28,7 @@
 @import './src/Progress/progress.css';
 @import './src/Radio/radio.css';
 @import './src/RangedDatepicker/rangedDatepicker.css';
+@import './src/RangedDatepickerInput/rangedDatepickerInput.css';
 @import './src/Search/search.css';
 @import './src/Slider/slider.css';
 @import './src/StatusTag/statusTag.css';

--- a/packages/orion/src/DatepickerInput/SharedInput/index.js
+++ b/packages/orion/src/DatepickerInput/SharedInput/index.js
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Popup } from '@inloco/semantic-ui-react'
 
 import Input from '../../Input'
@@ -8,6 +8,7 @@ import Input from '../../Input'
 const DatepickerSharedInput = ({
   className,
   disabled,
+  input,
   onChange,
   picker,
   popupProps,
@@ -16,13 +17,18 @@ const DatepickerSharedInput = ({
 }) => {
   const [opening, setOpening] = useState()
 
+  useEffect(() => {
+    if (opening) {
+      const timeout = setTimeout(() => setOpening(false))
+      return () => clearTimeout(timeout)
+    }
+  }, [opening])
+
   // We add a special CSS class for a short time after opening the
   // popup. That's because react dates takes a while to render, so
   // we wait a little bit until it's done to avoid flickering.
-  const handleTriggerClick = () => {
-    setOpening(true)
-    setTimeout(() => setOpening(false))
-  }
+  const handleTriggerClick = () => setOpening(true)
+
   return (
     <Popup
       className={cx('datepicker-input-popup', { opening })}
@@ -33,14 +39,16 @@ const DatepickerSharedInput = ({
           className={cx('datepicker-input-trigger', { disabled })}
           data-testid="datepicker-trigger"
           onClick={handleTriggerClick}>
-          <Input
-            className={cx('datepicker-input', className)}
-            disabled={disabled}
-            icon="date_range"
-            onChange={onChange}
-            value={value || ''}
-            {...otherProps}
-          />
+          {input || (
+            <Input
+              className={cx('datepicker-input', className)}
+              disabled={disabled}
+              icon="date_range"
+              onChange={onChange}
+              value={value || ''}
+              {...otherProps}
+            />
+          )}
         </div>
       }
       content={picker}
@@ -53,10 +61,11 @@ const DatepickerSharedInput = ({
 DatepickerSharedInput.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  input: PropTypes.node,
   onChange: PropTypes.func,
   picker: PropTypes.node.isRequired,
   popupProps: PropTypes.object,
-  value: PropTypes.string
+  value: PropTypes.any
 }
 
 DatepickerSharedInput.defaultProps = {

--- a/packages/orion/src/Form/Field/field.css
+++ b/packages/orion/src/Form/Field/field.css
@@ -10,6 +10,7 @@
 /* Floated label */
 .orion.form .field.floatingLabel label {
   @apply absolute border-l-1 top-0 block .cursor-text ml-16 pb-0 text-gray-800 text-base transition-default z-10;
+  @apply pointer-events-none;
   transition-property: margin-top, font-size;
   border-color: transparent !important;
   margin-top: 17px;
@@ -33,7 +34,8 @@
 }
 
 .orion.form .field.floatingLabel:focus-within .dropdown .default.text,
-.orion.form .field.floatingLabel:focus-within input::placeholder {
+.orion.form .field.floatingLabel:focus-within input::placeholder,
+.orion.form .field.floatingLabel.filled input::placeholder {
   @apply text-gray-800;
 }
 

--- a/packages/orion/src/RangedDatepickerInput/RangedDatepickerInput.stories.js
+++ b/packages/orion/src/RangedDatepickerInput/RangedDatepickerInput.stories.js
@@ -16,15 +16,16 @@ export default {
 
 export const basic = () => (
   <RangedDatepickerInput
-    placeholder={text('Placeholder', 'Type here')}
+    pickerProps={{
+      numberOfMonths: number('Number of months', 1)
+    }}
+    startPlaceholder={text('Start placeholder', 'Start')}
+    endPlaceholder={text('End placeholder', 'End')}
     size={sizeKnob()}
     error={boolean('error', false)}
     warning={boolean('warning', false)}
     disabled={boolean('disabled', false)}
     fluid={boolean('fluid', false)}
-    pickerProps={{
-      numberOfMonths: number('Number of months', 1)
-    }}
     {...actions}
   />
 )
@@ -42,7 +43,11 @@ const ControlledRangedDatepickerInput = props => {
 
 export const controlled = () => (
   <ControlledRangedDatepickerInput
-    placeholder={text('Placeholder', 'Type here')}
+    pickerProps={{
+      numberOfMonths: number('Number of months', 1)
+    }}
+    startPlaceholder={text('Start placeholder', 'Start')}
+    endPlaceholder={text('End placeholder', 'End')}
     size={sizeKnob()}
     error={boolean('error', false)}
     warning={boolean('warning', false)}
@@ -55,12 +60,14 @@ export const controlled = () => (
 export const insideForm = () => (
   <Form>
     <Form.Field>
-      <label htmlFor="date">
-        {text('RangedDatepickerInput label', 'Date Range')}
-      </label>
+      <label htmlFor="date">{text('Label', 'Date Range')}</label>
       <RangedDatepickerInput
         id="date"
-        placeholder={text('Placeholder', 'Type here')}
+        pickerProps={{
+          numberOfMonths: number('Number of months', 1)
+        }}
+        startPlaceholder={text('Start placeholder', 'Start')}
+        endPlaceholder={text('End placeholder', 'End')}
         size={sizeKnob()}
         error={boolean('error', false)}
         warning={boolean('warning', false)}

--- a/packages/orion/src/RangedDatepickerInput/RangedDatepickerInput.test.js
+++ b/packages/orion/src/RangedDatepickerInput/RangedDatepickerInput.test.js
@@ -5,11 +5,17 @@ import { fireEvent, render } from '@testing-library/react'
 import { RangedDatepickerInput } from '../'
 
 describe('when the input is clicked', () => {
-  const placeholder = 'Choose a date range'
+  const startPlaceholder = 'Start'
+  const endPlaceholder = 'End'
   let renderResult
 
   beforeEach(() => {
-    renderResult = render(<RangedDatepickerInput placeholder={placeholder} />)
+    renderResult = render(
+      <RangedDatepickerInput
+        startPlaceholder={startPlaceholder}
+        endPlaceholder={endPlaceholder}
+      />
+    )
 
     const { getByTestId } = renderResult
     fireEvent.click(getByTestId('datepicker-trigger'))
@@ -28,9 +34,9 @@ describe('when the input is clicked', () => {
       fireEvent.click(dayElement)
     })
 
-    it('should display the selected date in the input with an unknown end date', () => {
+    it('should display the selected date in the input', () => {
       const { queryByDisplayValue } = renderResult
-      expect(queryByDisplayValue('02/20/2020 - ?')).toBeTruthy()
+      expect(queryByDisplayValue('02/20/2020')).toBeTruthy()
     })
 
     it('should show the chosen date as selected in the calendar', () => {
@@ -46,9 +52,10 @@ describe('when the input is clicked', () => {
         fireEvent.click(dayElement)
       })
 
-      it('should display the selected date in the input with an unknown end date', () => {
+      it('should display both selected dates in the input', () => {
         const { queryByDisplayValue } = renderResult
-        expect(queryByDisplayValue('02/20/2020 - 02/22/2020')).toBeTruthy()
+        expect(queryByDisplayValue('02/20/2020')).toBeTruthy()
+        expect(queryByDisplayValue('02/22/2020')).toBeTruthy()
       })
 
       it('should show the chosen date as selected in the calendar', () => {
@@ -70,18 +77,21 @@ describe('when the input is clicked', () => {
     })
   })
 
-  describe('when a new date is typed in the input', () => {
+  describe('when a new date range is typed in the inpupt', () => {
     beforeEach(() => {
       const { getByPlaceholderText } = renderResult
-      const inputElement = getByPlaceholderText(placeholder)
-      fireEvent.change(inputElement, {
-        target: { value: '02/22/2020 - 02/24/2020' }
-      })
+
+      let inputElement = getByPlaceholderText(startPlaceholder)
+      fireEvent.change(inputElement, { target: { value: '02/22/2020' } })
+
+      inputElement = getByPlaceholderText(endPlaceholder)
+      fireEvent.change(inputElement, { target: { value: '02/24/2020' } })
     })
 
-    it('should display the new date in the input', () => {
+    it('should display the new dates in the input', () => {
       const { queryByDisplayValue } = renderResult
-      expect(queryByDisplayValue('02/22/2020 - 02/24/2020')).toBeTruthy()
+      expect(queryByDisplayValue('02/22/2020')).toBeTruthy()
+      expect(queryByDisplayValue('02/24/2020')).toBeTruthy()
     })
 
     it('should show the chosen date as selected in the calendar', () => {
@@ -105,7 +115,7 @@ describe('when the input is clicked', () => {
   describe('when an invalid date is typed in the input', () => {
     beforeEach(() => {
       const { getByPlaceholderText } = renderResult
-      const inputElement = getByPlaceholderText(placeholder)
+      const inputElement = getByPlaceholderText(startPlaceholder)
       fireEvent.change(inputElement, { target: { value: 'Not a date' } })
     })
 
@@ -118,10 +128,10 @@ describe('when the input is clicked', () => {
       const { rerender } = renderResult
       rerender(
         <RangedDatepickerInput
-          placeholder={placeholder}
+          startPlaceholder={startPlaceholder}
+          endPlaceholder={endPlaceholder}
           value={{
-            startDate: moment('Also not a date'),
-            endDate: moment('Also not a date')
+            startDate: moment('Also not a date')
           }}
         />
       )

--- a/packages/orion/src/RangedDatepickerInput/rangedDatepickerInput.css
+++ b/packages/orion/src/RangedDatepickerInput/rangedDatepickerInput.css
@@ -1,0 +1,58 @@
+.ranged-datepicker-input {
+  @apply flex items-center h-48 pl-16;
+  @apply bg-white border border-solid border-gray-900-24 rounded;
+  width: 256px;
+}
+
+.ranged-datepicker-input:hover {
+  @apply shadow-field-hover;
+}
+
+.ranged-datepicker-input:active,
+.ranged-datepicker-input:focus {
+  @apply shadow-field-active;
+}
+
+.ranged-datepicker-input .orion.input {
+  @apply flex-1 h-full;
+}
+
+.ranged-datepicker-input .orion.input > input {
+  @apply bg-transparent border-0 p-0;
+}
+
+.ranged-datepicker-input .orion.input > input:hover {
+  @apply shadow-none;
+}
+
+.ranged-datepicker-input .orion.input > input:active,
+.ranged-datepicker-input .orion.input > input:focus {
+  @apply shadow-none;
+}
+
+.ranged-datepicker-input .icon:not(.input) {
+  @apply flex flex-shrink-0 h-full items-center;
+}
+
+i.icon.ranged-datepicker-input-separator {
+  @apply mx-4 text-gray-500;
+  font-size: 16px;
+}
+
+.ranged-datepicker-input .icon:last-child {
+  @apply justify-center text-gray-700;
+  width: 40px;
+}
+
+/* Floating label */
+
+.orion.form .field.floatingLabel .ranged-datepicker-input-separator {
+  @apply hidden;
+}
+
+.orion.form .field.floatingLabel.filled .ranged-datepicker-input-separator,
+.orion.form
+  .field.floatingLabel:focus-within
+  .ranged-datepicker-input-separator {
+  @apply flex pt-16;
+}


### PR DESCRIPTION
Usando o novo **RangedDatepickerInput** eu entendi um motivo importante de o **react-dates** usar 2 inputs (um pra start date e outro pra end date) ao invés de apenas 1. Com 1 input temos apenas um placeholder, o que causa confusão quando uma das datas é opcional, por exemplo. Nós avisávamos que a data era opcional no placeholder dela, por exemplo:

<img width="361" alt="Screen Shot 2020-02-20 at 8 58 26 AM" src="https://user-images.githubusercontent.com/5216049/74947839-39727600-53da-11ea-9cf3-6ba0b787763b.png">

Com apenas 1 input, quando uma das datas é preenchida, mostramos algo assim:
<img width="281" alt="Screen Shot 2020-02-20 at 8 58 33 AM" src="https://user-images.githubusercontent.com/5216049/74947847-3aa3a300-53da-11ea-9825-d5ef58911d2b.png">

Ficou bem mais difícil entender que a data final seria opcional...

Falei com Bruno e ele achou melhor usarmos 2 inputs mesmo, e me passou o novo visual. Apliquei ele aqui e ficou assim:

![2020-02-20 12 17 15](https://user-images.githubusercontent.com/5216049/74948626-53f91f00-53db-11ea-9fc7-db2ce35a4e94.gif)

