### PR TITLE
fix(datepicker): Three fixes for the new datepickers

### DIFF
--- a/packages/orion/src/DatepickerInput/SharedInput/index.js
+++ b/packages/orion/src/DatepickerInput/SharedInput/index.js
@@ -8,6 +8,7 @@ import Input from '../../Input'
 const DatepickerSharedInput = ({
   className,
   disabled,
+  fluid,
   input,
   onChange,
   picker,
@@ -36,13 +37,14 @@ const DatepickerSharedInput = ({
       on="click"
       trigger={
         <div
-          className={cx('datepicker-input-trigger', { disabled })}
+          className={cx('datepicker-input-trigger', { disabled, fluid })}
           data-testid="datepicker-trigger"
           onClick={handleTriggerClick}>
           {input || (
             <Input
               className={cx('datepicker-input', className)}
               disabled={disabled}
+              fluid
               icon="date_range"
               onChange={onChange}
               value={value || ''}
@@ -61,6 +63,7 @@ const DatepickerSharedInput = ({
 DatepickerSharedInput.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  fluid: PropTypes.bool,
   input: PropTypes.node,
   onChange: PropTypes.func,
   picker: PropTypes.node.isRequired,

--- a/packages/orion/src/DatepickerInput/datepickerInput.css
+++ b/packages/orion/src/DatepickerInput/datepickerInput.css
@@ -6,6 +6,10 @@
   width: fit-content;
 }
 
+.datepicker-input-trigger.fluid {
+  @apply w-full;
+}
+
 .datepicker-input-trigger.disabled {
   @apply pointer-events-none;
 }

--- a/packages/orion/src/RangedDatepickerInput/index.js
+++ b/packages/orion/src/RangedDatepickerInput/index.js
@@ -22,6 +22,7 @@ const formatDates = (dates, displayFormat) => {
 const RangedDatepickerInput = ({
   className,
   defaultValue,
+  disabled,
   displayFormat,
   endPlaceholder,
   onChange,
@@ -79,9 +80,11 @@ const RangedDatepickerInput = ({
 
   return (
     <DatepickerSharedInput
+      disabled={disabled}
       input={
         <div className="ranged-datepicker-input">
           <Input
+            disabled={disabled}
             onChange={handleStartInputChange}
             placeholder={startPlaceholder}
             value={_.get(inputValues, 'startDate') || ''}
@@ -91,6 +94,7 @@ const RangedDatepickerInput = ({
             name="arrow_forward"
           />
           <Input
+            disabled={disabled}
             onChange={handleEndInputChange}
             placeholder={endPlaceholder}
             value={_.get(inputValues, 'endDate') || ''}
@@ -118,6 +122,7 @@ RangedDatepickerInput.propTypes = {
     startDate: PropTypes.any,
     endDate: PropTypes.any
   }),
+  disabled: PropTypes.bool,
   displayFormat: PropTypes.string,
   endPlaceholder: PropTypes.string,
   onChange: PropTypes.func,

--- a/packages/orion/src/RangedDatepickerInput/index.js
+++ b/packages/orion/src/RangedDatepickerInput/index.js
@@ -87,7 +87,7 @@ const RangedDatepickerInput = ({
             disabled={disabled}
             onChange={handleStartInputChange}
             placeholder={startPlaceholder}
-            value={_.get(inputValues, 'startDate') || ''}
+            value={_.get(value, 'startDate') || ''}
           />
           <Icon
             className="ranged-datepicker-input-separator"
@@ -97,7 +97,7 @@ const RangedDatepickerInput = ({
             disabled={disabled}
             onChange={handleEndInputChange}
             placeholder={endPlaceholder}
-            value={_.get(inputValues, 'endDate') || ''}
+            value={_.get(value, 'endDate') || ''}
           />
           <Icon name="date_range" />
         </div>

--- a/packages/orion/src/RangedDatepickerInput/rangedDatepickerInput.css
+++ b/packages/orion/src/RangedDatepickerInput/rangedDatepickerInput.css
@@ -4,6 +4,10 @@
   width: 256px;
 }
 
+.datepicker-input-trigger.fluid .ranged-datepicker-input {
+  @apply w-full;
+}
+
 .ranged-datepicker-input:hover {
   @apply shadow-field-hover;
 }
@@ -14,7 +18,8 @@
 }
 
 .ranged-datepicker-input .orion.input {
-  @apply flex-1 h-full;
+  @apply h-full;
+  width: 87px;
 }
 
 .ranged-datepicker-input .orion.input > input {
@@ -40,7 +45,7 @@ i.icon.ranged-datepicker-input-separator {
 }
 
 .ranged-datepicker-input .icon:last-child {
-  @apply justify-center text-gray-700;
+  @apply justify-center ml-auto text-gray-700;
   width: 40px;
 }
 

--- a/packages/orion/src/RangedDatepickerInput/rangedDatepickerInput.css
+++ b/packages/orion/src/RangedDatepickerInput/rangedDatepickerInput.css
@@ -44,6 +44,12 @@ i.icon.ranged-datepicker-input-separator {
   width: 40px;
 }
 
+/* Disabled */
+
+.datepicker-input-trigger.disabled .ranged-datepicker-input {
+  @apply bg-gray-900-8;
+}
+
 /* Floating label */
 
 .orion.form .field.floatingLabel .ranged-datepicker-input-separator {


### PR DESCRIPTION
Acredito que esses são os últimos! 🙏
3 fixes:

1. O **disabled** state parou de funcionar pra **RangedDatepickerInput** quando eu quebrei ele em 2 inputs. Ficou assim agora:
<img width="278" alt="Screen Shot 2020-02-20 at 4 02 36 PM" src="https://user-images.githubusercontent.com/5216049/74970045-78b1be80-53fc-11ea-8d5e-8dba7f39fb31.png">

2. O valor inicial mostrado pelo **RangedDatepickerInput** também parou de funcionar quando quebrei em 2 inputs.

3. A prop **fluid** não estava funcionando em ambos os datepickers. Ficou assim agora:
<img width="759" alt="Screen Shot 2020-02-20 at 4 14 07 PM" src="https://user-images.githubusercontent.com/5216049/74970047-794a5500-53fc-11ea-8328-e82ef98019a8.png">