### PR TITLE
feature(rangedDatepicker): Style out of range dates

### DIFF
--- a/packages/orion/src/Datepicker/datepicker.css
+++ b/packages/orion/src/Datepicker/datepicker.css
@@ -115,6 +115,7 @@
   @apply bg-wave-700;
 }
 
-.CalendarDay__blocked_calendar {
-  @apply cursor-not-allowed opacity-40;
+.CalendarDay__blocked_calendar,
+.CalendarDay__blocked_out_of_range {
+  @apply cursor-not-allowed opacity-32;
 }

--- a/packages/orion/src/RangedDatepicker/RangedDatepicker.stories.js
+++ b/packages/orion/src/RangedDatepicker/RangedDatepicker.stories.js
@@ -38,3 +38,11 @@ export const disabledMonths = () => {
     />
   )
 }
+
+export const disabledDates = () => {
+  const isOutsideRange = date => {
+    const dayOfWeek = date.format('dddd')
+    return dayOfWeek === 'Saturday' || dayOfWeek === 'Sunday'
+  }
+  return <RangedDatepicker isOutsideRange={isOutsideRange} {...actions} />
+}


### PR DESCRIPTION
Ok, agora sim deve ser o último... 🙏 

Faltava o estilo das datas out of range no datepicker. A gente já tinha esse estilo pra disabled dates, mas a classe usada pra o caso do ranged datepicker era diferente.

<img width="307" alt="Screen Shot 2020-02-20 at 5 14 00 PM" src="https://user-images.githubusercontent.com/5216049/74974769-9edb5c80-5404-11ea-963b-5b9162a6740d.png">
