### PR TITLE
fix(Dropdown): remove negative icon margin

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -57,7 +57,6 @@
 
 .orion.dropdown > .icon {
   @apply ml-auto;
-  margin-right: -8px;
 }
 
 .orion.dropdown.active .dropdown-icon {
@@ -176,7 +175,7 @@
  */
 
 .orion.dropdown.selection {
-  @apply bg-white border border-solid border-gray-900-24 px-16 rounded;
+  @apply bg-white border border-solid border-gray-900-24 pl-16 pr-8 rounded;
 }
 
 .orion.dropdown.selection.small {


### PR DESCRIPTION
Pequeno fix do problema que comentei la no chapter.

Com a margin negativa, o icone do dropdown acaba ficando fora do bounding box do dropdown:
![Screenshot from 2020-02-20 18-16-50](https://user-images.githubusercontent.com/9112403/74979327-30e76300-540d-11ea-9d5c-890310dc82a2.png)

Entao removi a margin negativa e ficou tudo certo.
![Screenshot from 2020-02-20 18-19-31](https://user-images.githubusercontent.com/9112403/74979528-8facdc80-540d-11ea-9296-8460127132cf.png)


@mairatma comentou que essa margin negativa eh por causa da distancia do icone do dropdown de selection. 
Entao, para o de selection, estou setando um padding a direita menor ao inves de usar a margin negativa. E o resultado eh visualmente o mesmo:
![Screenshot from 2020-02-20 18-18-42](https://user-images.githubusercontent.com/9112403/74979468-7310a480-540d-11ea-8d2e-a19c2181a269.png)
