### PR TITLE
feature(orion): Upgrade Spec

### DIFF
--- a/packages/atomic-bomb/css/base.css
+++ b/packages/atomic-bomb/css/base.css
@@ -9,12 +9,9 @@ body {
   @apply font-default text-gray-900 leading-20 text-base;
 }
 
-h1 {
-  @apply font-display tracking-h1 text-xl text-gray-800 leading-28;
-}
-
+h1,
 h2 {
-  @apply font-display tracking-h2 text-lg text-gray-800 leading-24;
+  @apply font-display tracking-h1 text-lg text-gray-800 leading-24;
 }
 
 a {

--- a/packages/atomic-bomb/css/font.css
+++ b/packages/atomic-bomb/css/font.css
@@ -2,14 +2,15 @@
 
 @font-face {
   font-family: 'neue-haas-grotesk-display';
-  src: url('https://use.typekit.net/af/9395af/00000000000000003b9b2046/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
+  src: url('https://use.typekit.net/af/8a200c/00000000000000003b9b204a/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
       format('woff2'),
-    url('https://use.typekit.net/af/9395af/00000000000000003b9b2046/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
+    url('https://use.typekit.net/af/8a200c/00000000000000003b9b204a/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
       format('woff'),
-    url('https://use.typekit.net/af/9395af/00000000000000003b9b2046/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
+    url('https://use.typekit.net/af/8a200c/00000000000000003b9b204a/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
       format('opentype');
+  font-display: auto;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 600;
 }
 
 @font-face {

--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -265,8 +265,8 @@ module.exports = {
     fontSize: {
       sm: '12px',
       base: '14px',
-      lg: '20px',
-      xl: '24px'
+      lg: '18px',
+      xl: '20px'
     },
     fontWeight: {
       normal: '400',
@@ -292,8 +292,7 @@ module.exports = {
       // 12/14, 14/20, 20/24, 24/28
       '14': '14px',
       '20': '20px',
-      '24': '24px',
-      '28': '28px'
+      '24': '24px'
     },
     listStyleType: {
       none: 'none',

--- a/packages/orion/src/Icon/icon.css
+++ b/packages/orion/src/Icon/icon.css
@@ -1,5 +1,5 @@
 i.orion.icon {
-  @apply text-lg text-left;
+  @apply text-xl text-left;
 }
 
 svg.icon {

--- a/packages/orion/src/Message/message.css
+++ b/packages/orion/src/Message/message.css
@@ -1,5 +1,9 @@
 .orion.message {
-  @apply border-1 border-green-500 rounded bg-green-50 p-16 text-base flex items-center;
+  @apply rounded bg-green-50 p-8 text-base flex items-center;
+}
+
+.orion.message.header {
+  @apply p-16;
 }
 
 .orion.message .header {
@@ -7,18 +11,22 @@
 }
 
 .orion.message.info {
-  @apply border-gray-900-8 bg-gray-100;
+  @apply bg-gray-100;
 }
 
 .orion.message.error {
-  @apply border-magenta-500 bg-magenta-50;
+  @apply bg-magenta-50;
 }
 
 .orion.message.warning {
-  @apply border-yellow-500 bg-yellow-50;
+  @apply bg-yellow-50;
 }
 
 .orion.message > .icon {
+  @apply p-2 pr-8;
+}
+
+.orion.message.header > .icon {
   @apply pr-16;
 }
 


### PR DESCRIPTION
Seguindo o que foi discutido no canal #orion, eu fiz o upgrade de spec:

Mudanças que impactam o front:
* O tamanho XL da fonte (24px) morreu.
*Update*: Na verdade não morreu, a gente deixou ele pra 20px, porque ele pode ser usado como o tamanho de ícone.
* O tamanho LG (20px) passa a ser 18px e line-height 24px
* Atualização da UI dos alerts (morreram as bordas e ajuste de padding)

![image](https://user-images.githubusercontent.com/1139664/75807610-72103900-5d64-11ea-8983-c271e712334c.png)


Mais info no slack canal #orion.
