### PR TITLE
Feature/icons font size

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -266,7 +266,9 @@ module.exports = {
       sm: '12px',
       base: '14px',
       lg: '18px',
-      xl: '20px'
+      xl: '20px',
+      'icon-sm': '16px',
+      'icon-md': '20px'
     },
     fontWeight: {
       normal: '400',

--- a/packages/orion/src/Dialog/dialog.css
+++ b/packages/orion/src/Dialog/dialog.css
@@ -19,7 +19,7 @@
 }
 
 .orion.modal.dialog > .header::before {
-  @apply font-icons mb-8 text-lg text-space-600;
+  @apply font-icons mb-8 text-icon-md text-space-600;
   content: 'info';
 }
 

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -128,7 +128,7 @@
 }
 
 .orion.dropdown.multiple.keep-selected > .menu > .item::after {
-  @apply absolute text-lg text-wave-500;
+  @apply absolute text-icon-md text-wave-500;
   top: calc(50% - 10px);
   right: 16px;
 }

--- a/packages/orion/src/Filter/filter.css
+++ b/packages/orion/src/Filter/filter.css
@@ -30,10 +30,9 @@
 /** Trigger button's icon **/
 
 .orion.button.filter-trigger .icon {
-  @apply ml-4 rounded-full text-space-600;
+  @apply ml-4 rounded-full text-space-600 text-icon-sm;
   @apply h-16 w-16;
   @apply transition-default;
-  font-size: 16px;
   transition-property: background-color, color;
 }
 

--- a/packages/orion/src/Icon/icon.css
+++ b/packages/orion/src/Icon/icon.css
@@ -1,5 +1,5 @@
 i.orion.icon {
-  @apply text-xl text-left;
+  @apply text-icon-md text-left;
 }
 
 svg.icon {

--- a/packages/orion/src/InfoIcon/infoIcon.css
+++ b/packages/orion/src/InfoIcon/infoIcon.css
@@ -1,4 +1,3 @@
 .orion.icon.info-icon {
-  @apply cursor-default select-none text-gray-600;
-  font-size: 16px;
+  @apply cursor-default select-none text-gray-600 text-icon-sm;
 }

--- a/packages/orion/src/RangedDatepickerInput/rangedDatepickerInput.css
+++ b/packages/orion/src/RangedDatepickerInput/rangedDatepickerInput.css
@@ -40,8 +40,7 @@
 }
 
 i.icon.ranged-datepicker-input-separator {
-  @apply mx-4 text-gray-500;
-  font-size: 16px;
+  @apply mx-4 text-gray-500 text-icon-sm;
 }
 
 .ranged-datepicker-input .icon:last-child {

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -92,7 +92,7 @@
 }
 
 .orion.table.sortable th.sorted > .inner-cell::after {
-  @apply absolute text-gray-700 text-lg transition-default font-icons;
+  @apply absolute text-gray-700 text-icon-md transition-default font-icons;
   content: 'keyboard_arrow_up';
   transition-property: transform;
 }


### PR DESCRIPTION
Comentei com Bruno a questão do font-size: 16px para ícones que não estava definida e comentamos no PR https://github.com/inloco/orion/pull/538. Ele falou que de fato poderíamos ter as definições de 16px e 20px para o font-size. Ele sugeriu criarmos regras novas específicamente para o font-size de ícones. 
https://inlocoglobal.slack.com/archives/CSGDFBKL6/p1582911973000500

Então estou adicionando as regras `text-icon-sm` e  `text-icon-md` e trocando onde necessário.
