### PR TITLE
fix(LayoutUserProfile): fix dimensions and colors

### DIFF
--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -29,7 +29,7 @@ const LayoutUserProfile = ({
     <Dropdown
       className={cx('layout-user-profile', className)}
       trigger={
-        <div>
+        <div className="layout-user-profile-trigger">
           <div className="layout-user-profile-name">{name}</div>
           {label && <label>{label}</label>}
         </div>

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -5,12 +5,20 @@
   @apply rounded px-8 py-4 whitespace-no-wrap;
 }
 
-.orion.layout .layout-user-profile:hover,
-.orion.layout .layout-user-profile.active {
+.orion.layout .layout-user-profile-trigger {
+  @apply flex flex-col;
+}
+
+.orion.layout .layout-user-profile:hover {
   @apply bg-gray-900-8;
 }
 
+.orion.layout .layout-user-profile.active {
+  @apply bg-gray-900-12;
+}
+
 .orion.layout .layout-user-profile > .icon {
+  @apply text-gray-700;
   margin-left: 4px !important;
 }
 


### PR DESCRIPTION
Pequenos fixes no componente de User Profile.

1. A div dos textos estava com o display default (block), daí tinha um espaço entre as linhas que deixava a caixa maior do que deveria ser (o tamanho correto é  42px, ela estava com 48px)

2. O hover e o active estavam com a mesma cor. Na vdd, o active precisa ter uma opacidade de valor maior, para ficar mais escuro.

3. A cor do ícone da setinha não estava setada.

GIF com antes e depois
![orion-user-profile-fix](https://user-images.githubusercontent.com/9112403/76529072-8634f400-6450-11ea-8a13-fa4fb07651f0.gif)