### PR TITLE
feat(LayoutUserProfile): set maxHeight to userProfile

### DIFF
--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -49,12 +49,14 @@ const LayoutUserProfile = ({
             </>
           )}
         </Dropdown.Header>
-        {!_.isEmpty(otherChildren) && (
-          <>
-            <Dropdown.Divider />
-            {otherChildren}
-          </>
-        )}
+        <div className="layout-user-profile-children-container">
+          {!_.isEmpty(otherChildren) && (
+            <>
+              <Dropdown.Divider />
+              {otherChildren}
+            </>
+          )}
+        </div>
         <Dropdown.Divider />
         <form
           className="layout-user-profile-logout"

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -37,6 +37,11 @@
   width: 320px !important;
 }
 
+.orion.layout .layout-user-profile-children-container {
+  @apply overflow-y-auto;
+  max-height: 433px; /* Six times 72px plus 1px divider */
+}
+
 /**
  * Dropdown Header
  */


### PR DESCRIPTION
Adicionando uma altura máxima para o menu de userProfile. Victinho definiu com um limite máximo de 6 itens no menu.

![orion-user-profile-scroll](https://user-images.githubusercontent.com/9112403/76556753-e8095400-6478-11ea-9ea1-c90ad366daaa.gif)
