### PR TITLE
feature(wizard): Add Cancel button and change button's position

### DIFF
--- a/packages/orion/src/Wizard/Wizard.stories.js
+++ b/packages/orion/src/Wizard/Wizard.stories.js
@@ -10,6 +10,8 @@ const actions = {
 }
 
 const buttons = {
+  [Wizard.Buttons.CANCEL]: <Button>Cancel</Button>,
+  [Wizard.Buttons.SAVE]: <Button>Save</Button>,
   [Wizard.Buttons.NEXT]: <Button>Next</Button>,
   [Wizard.Buttons.BACK]: <Button>Return</Button>,
   [Wizard.Buttons.FINISH]: <Button onClick={actions.onFinish}>Complete</Button>

--- a/packages/orion/src/Wizard/WizardControls/index.js
+++ b/packages/orion/src/Wizard/WizardControls/index.js
@@ -5,8 +5,9 @@ import React from 'react'
 import Button from '../../Button'
 
 export const WizardButtons = {
-  BACK: 'back',
+  CANCEL: 'cancel',
   SAVE: 'save',
+  BACK: 'back',
   NEXT: 'next',
   FINISH: 'finish'
 }
@@ -28,26 +29,32 @@ const WizardControls = ({
 
   return (
     <div className="wizard-controls">
-      {currentStepIndex > 0 &&
-        Button.create(buttons[WizardButtons.BACK], {
+      {buttons[WizardButtons.CANCEL] &&
+        Button.create(buttons[WizardButtons.CANCEL], {
           autoGenerateKey: false,
           defaultProps: {
             type: 'button'
-          },
-          overrideProps: overrideOnClick(() =>
-            onStepIndexChange(currentStepIndex - 1)
-          )
+          }
+        })}
+
+      {buttons[WizardButtons.SAVE] &&
+        !isLastStep &&
+        Button.create(buttons[WizardButtons.SAVE], {
+          autoGenerateKey: false,
+          defaultProps: {
+            type: 'submit'
+          }
         })}
       <div className="wizard-controls-right">
-        {buttons[WizardButtons.SAVE] &&
-          !isLastStep &&
-          Button.create(buttons[WizardButtons.SAVE], {
+        {currentStepIndex > 0 &&
+          Button.create(buttons[WizardButtons.BACK], {
             autoGenerateKey: false,
             defaultProps: {
-              className: 'mr-8',
-              ghost: true,
-              type: 'submit'
-            }
+              type: 'button'
+            },
+            overrideProps: overrideOnClick(() =>
+              onStepIndexChange(currentStepIndex - 1)
+            )
           })}
         {!isLastStep &&
           Button.create(buttons[WizardButtons.NEXT], {


### PR DESCRIPTION
Bruno pediu pra eu fazer uns ajustes no Wizard...

1. Adicionamos o botão de `Cancel`, não obrigatório.
2. Movemos o botão de `Back` para o lado direito, junto do `Next`.
3. Movemos o botão de `Save` para a esquerda, junto do `Cancel`.
4. O botão `Save` estava como ghost, mas deveria ser o cinza.

Resultado:
![image](https://user-images.githubusercontent.com/1139664/76766611-0754f980-6777-11ea-8d85-370f607f358b.png)
