### PR TITLE
Feature/layout tooltips

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -39,7 +39,7 @@
 }
 
 .orion.dropdown > .menu {
-  @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full z-20 overflow-visible;
+  @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full z-20;
   top: 100%;
 }
 

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -39,7 +39,7 @@
 }
 
 .orion.dropdown > .menu {
-  @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full z-20;
+  @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full z-20 overflow-visible;
   top: 100%;
 }
 

--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -68,7 +68,8 @@ export const basic = () => (
               <img src={appImage} alt="organization icon" />
             </Layout.UserProfile.Icon>
             {boolean('Button', true, 'UserProfile.HeaderItem') && (
-              <Layout.UserProfile.Button>
+              <Layout.UserProfile.Button
+                tooltip={text('Button tooltip', 'Back to Home', 'UserProfile')}>
                 <Icon name="home" />
               </Layout.UserProfile.Button>
             )}

--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -50,6 +50,7 @@ export const basic = () => (
           ],
           'AppsDropdown'
         )}
+        tooltip={text('Tooltip', 'Switch Product', 'AppsDropdown')}
         onChange={action('onChange')}
       />
       <Layout.Topbar.Divider />

--- a/packages/orion/src/Layout/LayoutAppsDropdown/index.js
+++ b/packages/orion/src/Layout/LayoutAppsDropdown/index.js
@@ -65,6 +65,7 @@ LayoutAppsDropdown.propTypes = {
       })
     })
   ),
+  tooltip: PropTypes.string,
   onChange: PropTypes.func
 }
 

--- a/packages/orion/src/Layout/LayoutAppsDropdown/index.js
+++ b/packages/orion/src/Layout/LayoutAppsDropdown/index.js
@@ -4,15 +4,18 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Image, Dropdown } from '@inloco/semantic-ui-react'
 
+import Tooltip from '../../Tooltip'
+
 const LayoutAppsDropdown = ({
   className,
   options,
+  tooltip,
   onChange,
   ...otherProps
 }) => {
   const [selectedOptions, otherOptions] = _.partition(options, 'selected')
 
-  return (
+  const dropdown = (
     <Dropdown
       className={cx('layout-apps-dropdown', className)}
       icon="apps"
@@ -43,6 +46,12 @@ const LayoutAppsDropdown = ({
         })}
       </Dropdown.Menu>
     </Dropdown>
+  )
+
+  return tooltip ? (
+    <Tooltip trigger={dropdown} position="bottom center" content={tooltip} />
+  ) : (
+    dropdown
   )
 }
 

--- a/packages/orion/src/Layout/LayoutUserProfile/UserProfileButton/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/UserProfileButton/index.js
@@ -1,9 +1,15 @@
 import React from 'react'
 
 import Button from '../../../Button'
+import Tooltip from '../../../Tooltip'
 
-const UserProfileButton = props => {
-  return <Button secondary subtle icon {...props} />
+const UserProfileButton = ({ tooltip, ...props }) => {
+  const button = <Button secondary subtle icon {...props} />
+  return tooltip ? (
+    <Tooltip trigger={button} position="top center" content={tooltip} />
+  ) : (
+    button
+  )
 }
 
 export default UserProfileButton

--- a/packages/orion/src/Layout/LayoutUserProfile/UserProfileButton/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/UserProfileButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import Button from '../../../Button'
 import Tooltip from '../../../Tooltip'
@@ -10,6 +11,10 @@ const UserProfileButton = ({ tooltip, ...props }) => {
   ) : (
     button
   )
+}
+
+UserProfileButton.propTypes = {
+  tooltip: PropTypes.string
 }
 
 export default UserProfileButton

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -34,6 +34,7 @@
  * Dropdown Menu
  */
 .orion.layout .layout-user-profile > .menu {
+  @apply overflow-visible;
   width: 320px !important;
 }
 

--- a/packages/orion/src/Tooltip/tooltip.css
+++ b/packages/orion/src/Tooltip/tooltip.css
@@ -5,3 +5,11 @@
 .orion.popup.tooltip:before {
   @apply bg-gray-800;
 }
+
+.orion.popup.tooltip.top {
+  @apply mb-12;
+}
+
+.orion.popup.tooltip.bottom {
+  @apply mt-12;
+}


### PR DESCRIPTION
Adicionando Tooltips nos botões do UserProfile e  no trigger do AppsDropdown.

Precisei ajustar o `overflow` do Menu para que Tooltip pudesse ser renderizado "para fora" dele.

Caso a prop `tooltip` esteja vazia, o componente `Tooltip` não será renderizado.

![Peek 2020-03-18 11-43](https://user-images.githubusercontent.com/9112403/76973615-f2ab6980-690e-11ea-9a11-ce17e1de3c4b.gif)
