### PR TITLE
fix(LayoutAppsDropdown): add Tooltip to icon instead of whole dropdown

### DIFF
--- a/packages/orion/src/Layout/LayoutAppsDropdown/index.js
+++ b/packages/orion/src/Layout/LayoutAppsDropdown/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Image, Dropdown } from '@inloco/semantic-ui-react'
 
+import Icon from '../../Icon'
 import Tooltip from '../../Tooltip'
 
 const LayoutAppsDropdown = ({
@@ -15,10 +16,18 @@ const LayoutAppsDropdown = ({
 }) => {
   const [selectedOptions, otherOptions] = _.partition(options, 'selected')
 
-  const dropdown = (
+  const icon = <Icon name="apps" />
+
+  return (
     <Dropdown
       className={cx('layout-apps-dropdown', className)}
-      icon="apps"
+      icon={
+        tooltip ? (
+          <Tooltip trigger={icon} position="bottom center" content={tooltip} />
+        ) : (
+          icon
+        )
+      }
       {...otherProps}>
       <Dropdown.Menu>
         {_.map(selectedOptions, ({ text, image }, index) => (
@@ -46,12 +55,6 @@ const LayoutAppsDropdown = ({
         })}
       </Dropdown.Menu>
     </Dropdown>
-  )
-
-  return tooltip ? (
-    <Tooltip trigger={dropdown} position="bottom center" content={tooltip} />
-  ) : (
-    dropdown
   )
 }
 


### PR DESCRIPTION
No meu ultimo PR nao testei bem o AppsDropdown e acabei deixando um bug que faz o Tooltip aparecer quando o cursor vai pro  menu aberto. Isso acontece pq coloquei o Tooltip em todo o componente. 
![Peek 2020-03-18 14-09](https://user-images.githubusercontent.com/9112403/76987788-83d80b80-6922-11ea-8106-11114a271f07.gif)


Estou mudando para adicionar  o tooltip apenas no `Icon` usado como trigger pro Dropdown.

