### PR TITLE
feat(Layout): update apps-dropdown style

### DIFF
--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -96,18 +96,18 @@
  * Apps Dropdown Item
  */
 .orion.layout .layout-apps-dropdown > .menu > .item {
-  @apply flex items-center m-8 rounded py-8 px-24;
+  @apply flex items-center py-16 px-32;
 }
 
 .orion.layout .layout-apps-dropdown > .menu > .item:hover {
-  @apply bg-gray-900-8;
+  @apply bg-gray-200;
 }
 
 /**
  * Apps Dropdown Image
  */
 .orion.layout .layout-apps-dropdown-image {
-  @apply flex justify-center items-center bg-white overflow-hidden mr-8 w-32 h-32 rounded-full border border-gray-400;
+  @apply flex justify-center items-center bg-gray-400 overflow-hidden mr-8 w-32 h-32 rounded-full border border-gray-400;
 }
 
 .orion.layout .layout-apps-dropdown-image > .orion.image {


### PR DESCRIPTION
Victinho atualizou o estilo do Dropdown de troca de produtos. Houveram mudancas na cor do bg das imagens e a remocao do "padding" no hover dos itens

Antes era assim
![Screenshot from 2020-03-19 10-12-46](https://user-images.githubusercontent.com/9112403/77071267-7c6c3d00-69ca-11ea-8af3-7566b3340513.png)

Atualizei para ficar assim:
![Screenshot from 2020-03-19 10-11-46](https://user-images.githubusercontent.com/9112403/77071286-84c47800-69ca-11ea-95b1-b90135f3302f.png)
