### PR TITLE
Feature/user profile edit link

### DIFF
--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -60,6 +60,12 @@ export const basic = () => (
         email={text('Email', 'mark.weiser@inloco.com.br', 'UserProfile')}
         logoutUrl={text('Logout URL', '#', 'UserProfile')}
         logoutText={text('Logout Text', 'Logout', 'UserProfile')}>
+        {boolean('Enabled', true, 'UserProfile.EditLink') && (
+          <Layout.UserProfile.EditLink
+            href={text('href', '#', 'UserProfile.EditLink')}>
+            {text('Text', 'My Profile', 'UserProfile.EditLink')}
+          </Layout.UserProfile.EditLink>
+        )}
         {boolean('Enabled', true, 'UserProfile.HeaderItem') && (
           <Layout.UserProfile.HeaderItem
             selected={boolean('Selected', true, 'UserProfile.HeaderItem')}

--- a/packages/orion/src/Layout/LayoutUserProfile/UserProfileEditLink/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/UserProfileEditLink/index.js
@@ -1,0 +1,31 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import Icon from '../../../Icon'
+
+const UserProfileEditLink = ({
+  as: AsElementType,
+  className,
+  children,
+  ...otherProps
+}) => {
+  const ElementType = AsElementType || 'a'
+
+  return (
+    <ElementType
+      className={cx('user-profile-edit-link', className)}
+      {...otherProps}>
+      <Icon name="edit" />
+      {children}
+    </ElementType>
+  )
+}
+
+UserProfileEditLink.propTypes = {
+  as: PropTypes.elementType,
+  className: PropTypes.string,
+  children: PropTypes.node
+}
+
+export default UserProfileEditLink

--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -19,8 +19,6 @@ const LayoutUserProfile = ({
   label,
   logoutUrl,
   logoutText,
-  profileUrl,
-  profileText,
   onLogout,
   ...otherProps
 }) => {

--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -5,6 +5,7 @@ import React from 'react'
 
 import Icon from '../../Icon'
 import Dropdown from '../../Dropdown'
+import UserProfileEditLink from './UserProfileEditLink'
 import UserProfileHeaderItem from './UserProfileHeaderItem'
 import UserProfileIcon from './UserProfileIcon'
 import UserProfileButton from './UserProfileButton'
@@ -18,13 +19,19 @@ const LayoutUserProfile = ({
   label,
   logoutUrl,
   logoutText,
+  profileUrl,
+  profileText,
   onLogout,
   ...otherProps
 }) => {
-  const [headerChildren, otherChildren] = _.partition(
+  const [headerChildren, notHeaderChildren] = _.partition(
     React.Children.toArray(children),
     { type: UserProfileHeaderItem }
   )
+
+  const [editLinkChildren, otherChildren] = _.partition(notHeaderChildren, {
+    type: UserProfileEditLink
+  })
 
   return (
     <Dropdown
@@ -43,6 +50,7 @@ const LayoutUserProfile = ({
         <Dropdown.Header>
           <div className="layout-user-profile-header-name">{name}</div>
           <div className="layout-user-profile-header-email">{email}</div>
+          {editLinkChildren}
           {!_.isEmpty(headerChildren) && (
             <>
               <Dropdown.Divider />
@@ -85,6 +93,7 @@ LayoutUserProfile.propTypes = {
   onLogout: PropTypes.func
 }
 
+LayoutUserProfile.EditLink = UserProfileEditLink
 LayoutUserProfile.HeaderItem = UserProfileHeaderItem
 LayoutUserProfile.Icon = UserProfileIcon
 LayoutUserProfile.Button = UserProfileButton

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -31,6 +31,27 @@
 }
 
 /**
+ * Edit Link
+ */
+.orion.layout .user-profile-edit-link {
+  @apply flex text-sm items-center m-auto text-wave-600;
+  margin-top: 6px;
+  width: fit-content;
+}
+
+.orion.layout .user-profile-edit-link:hover {
+  @apply text-wave-700;
+}
+
+.orion.layout .user-profile-edit-link:active {
+  @apply text-wave-800;
+}
+
+.orion.layout .user-profile-edit-link > .orion.icon {
+  @apply text-icon-sm mr-4;
+}
+
+/**
  * Dropdown Menu
  */
 .orion.layout .layout-user-profile > .menu {
@@ -55,7 +76,11 @@
 }
 
 .orion.layout .layout-user-profile .layout-user-profile-header-email {
-  @apply text-center pb-16;
+  @apply text-center;
+}
+
+.orion.layout .layout-user-profile .header .orion.divider {
+  @apply mt-16;
 }
 
 /**


### PR DESCRIPTION
Adicionando o botao de editar perfil. 
![Peek 2020-03-19 11-38](https://user-images.githubusercontent.com/9112403/77079629-176b1400-69d7-11ea-9eba-90b716078a1a.gif)

Adicionei mais um sub-componente ao UserProfile. A razao pela qual eu fiz isso ao inves de definir props foi para nos possibilitar usar o `as` para renderizar componentes diferentes ao inves do `<a>` em diferentes casos. Por exemplo, no inloco-frontend vamos querer usar o `Link` to react-router para nao sair da pagina.

Dai usariamos algo como
``` 
<Layout.UserProfile ...props>
    <Layout.UserProfile.EditLink as={Link} to="...">My Profile</Layout.UserProfile.EditLink>
    ...
</Layout.UserProfile>
```
