### PR TITLE
Feature/user profile image

### DIFF
--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -59,7 +59,8 @@ export const basic = () => (
         label={text('Label', 'In Loco', 'UserProfile')}
         email={text('Email', 'mark.weiser@inloco.com.br', 'UserProfile')}
         logoutUrl={text('Logout URL', '#', 'UserProfile')}
-        logoutText={text('Logout Text', 'Logout', 'UserProfile')}>
+        logoutText={text('Logout Text', 'Logout', 'UserProfile')}
+        imageUrl={text('Image URL', appImage, 'UserProfile')}>
         {boolean('Enabled', true, 'UserProfile.EditLink') && (
           <Layout.UserProfile.EditLink
             href={text('href', '#', 'UserProfile.EditLink')}>

--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -19,6 +19,7 @@ const LayoutUserProfile = ({
   label,
   logoutUrl,
   logoutText,
+  imageUrl,
   onLogout,
   ...otherProps
 }) => {
@@ -46,6 +47,13 @@ const LayoutUserProfile = ({
       {...otherProps}>
       <Dropdown.Menu>
         <Dropdown.Header>
+          <div className="layout-user-profile-image">
+            {imageUrl ? (
+              <img alt="user-profile" src={imageUrl} />
+            ) : (
+              <Icon name="person" />
+            )}
+          </div>
           <div className="layout-user-profile-header-name">{name}</div>
           <div className="layout-user-profile-header-email">{email}</div>
           {editLinkChildren}
@@ -88,6 +96,7 @@ LayoutUserProfile.propTypes = {
   label: PropTypes.string,
   logoutUrl: PropTypes.string,
   logoutText: PropTypes.string,
+  imageUrl: PropTypes.string,
   onLogout: PropTypes.func
 }
 

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -31,6 +31,19 @@
 }
 
 /**
+ * User Image
+ */
+.orion.layout .layout-user-profile-image {
+  @apply flex items-center justify-center m-auto w-64 h-64 rounded-full overflow-hidden bg-gray-400;
+}
+
+.orion.layout .layout-user-profile-image > .orion.icon {
+  @apply text-gray-500;
+  font-size: 48px;
+  line-height: 32px;
+}
+
+/**
  * Edit Link
  */
 .orion.layout .user-profile-edit-link {
@@ -68,11 +81,11 @@
  * Dropdown Header
  */
 .orion.layout .layout-user-profile .header {
-  @apply cursor-auto;
+  @apply cursor-auto pt-16;
 }
 
 .orion.layout .layout-user-profile .layout-user-profile-header-name {
-  @apply text-center font-medium pt-16;
+  @apply text-center font-medium pt-8;
 }
 
 .orion.layout .layout-user-profile .layout-user-profile-header-email {


### PR DESCRIPTION
Adicionando a imagem no Menu de perfil do usuario. Ela eh definida comuma prop `imageUrl`.
![Peek 2020-03-19 17-45](https://user-images.githubusercontent.com/9112403/77113762-24edc180-6a0a-11ea-98d0-a3d3f330fb36.gif)


No prototipo eh utilizado um SVG para o placeholder, mas utilizei o Icon para evitar adicionar um arquivo adicional no projeto. O bounding box do icone eh um pouco maior do que se observa, por isso precisei setar o font-size para mais do que 32px. Mas visualmente da pra ver que a parte visivel do icone ocupa 32px mesmo.
![Screenshot from 2020-03-19 17-51-28](https://user-images.githubusercontent.com/9112403/77113862-49e23480-6a0a-11ea-8bee-05aab83f32a1.png)


