### PR TITLE
fix(wizard-controls): Increase distance between content and controls

### DIFF
--- a/packages/orion/src/Wizard/wizard.css
+++ b/packages/orion/src/Wizard/wizard.css
@@ -3,7 +3,7 @@
 }
 
 .orion.wizard .wizard-controls {
-  @apply flex mt-24;
+  @apply flex mt-40;
 }
 
 .orion.wizard .wizard-controls-right {


### PR DESCRIPTION
Outro ajuste solicitado por Bruno.

Aumentar a distância entre o conteúdo do wizard e os botões.

Antes:
![image](https://user-images.githubusercontent.com/1139664/77320619-a9349300-6cef-11ea-9741-d4636698ed7e.png)

Depois:
![image](https://user-images.githubusercontent.com/1139664/77320651-b94c7280-6cef-11ea-9740-e95f55ceede2.png)

Visão geral:
![image](https://user-images.githubusercontent.com/1139664/77320745-e26d0300-6cef-11ea-89de-9161d8b94ec9.png)


