### PR TITLE
fix(Dimmer): prevent dimmable components from scrolling

### DIFF
--- a/packages/orion/src/Dimmer/dimmer.css
+++ b/packages/orion/src/Dimmer/dimmer.css
@@ -12,3 +12,14 @@
 .orion.dimmer.inverted {
   background-color: rgba(0, 0, 0, 0.66);
 }
+
+/*******************************
+             Scrolling
+*******************************/
+
+.dimmable.dimmed {
+  overflow: hidden;
+}
+.dimmable > .orion.dimmer {
+  position: fixed;
+}


### PR DESCRIPTION
Corrige a issue https://github.com/inloco/orion/issues/581

O dimmer não estava previnindo o scroll do componente abaixo.

![2020-03-23 12 11 40](https://user-images.githubusercontent.com/28961613/77333755-a4c5a580-6d02-11ea-9f6c-5a9da228d50d.gif)
![2020-03-23 12 13 57](https://user-images.githubusercontent.com/28961613/77333775-aee7a400-6d02-11ea-9224-fe60d778e5cb.gif)

