### PR TITLE
Fix/tags input default props

### DIFF
--- a/packages/orion/src/Form/Field/index.js
+++ b/packages/orion/src/Form/Field/index.js
@@ -25,7 +25,7 @@ const FLOATING_LABEL_COMPONENTS = [
 const isValueEmpty = value => !_.isNumber(value) && _.isEmpty(value)
 
 const shouldHaveFloatingLabel = (field, size) =>
-  FLOATING_LABEL_COMPONENTS.includes(field) && size === Sizes.DEFAULT
+  FLOATING_LABEL_COMPONENTS.includes(field) && size !== Sizes.SMALL
 
 const isFilled = (value, children) => {
   let filled = !isValueEmpty(value)

--- a/packages/orion/src/TagsInput/index.js
+++ b/packages/orion/src/TagsInput/index.js
@@ -39,6 +39,7 @@ const TagsInput = ({ className, defaultValue, onChange, ...otherProps }) => {
       multiple
       search
       selection
+      icon={null}
       options={options}
       value={values}
       searchQuery={search}


### PR DESCRIPTION
um fix de 2 besteirinhas. 
(1): o <Form.Field> só tava pegando com componente que tinha `size`. troquei pra fazer a checagem negando o Size.SMALL
(2): esse icon={null} é pra resolver um aumento de margem que dava por causa do icone escondido que tinha no html do dropdown