### PR TITLE
Feature/user profile image and spacing

### DIFF
--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -25,7 +25,9 @@ const LayoutUserProfile = ({
 }) => {
   const [headerChildren, notHeaderChildren] = _.partition(
     React.Children.toArray(children),
-    { type: UserProfileHeaderItem }
+    {
+      type: UserProfileHeaderItem
+    }
   )
 
   const [editLinkChildren, otherChildren] = _.partition(notHeaderChildren, {
@@ -37,8 +39,17 @@ const LayoutUserProfile = ({
       className={cx('layout-user-profile', className)}
       trigger={
         <div className="layout-user-profile-trigger">
-          <div className="layout-user-profile-name">{name}</div>
-          {label && <label>{label}</label>}
+          <div className="layout-user-profile-image">
+            {imageUrl ? (
+              <img alt="user-profile" src={imageUrl} />
+            ) : (
+              <Icon name="person" />
+            )}
+          </div>
+          <div className="layout-user-profile-trigger-texts">
+            {name}
+            {label && <label>{label}</label>}
+          </div>
         </div>
       }
       compact

--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -68,22 +68,22 @@ const LayoutUserProfile = ({
           <div className="layout-user-profile-header-name">{name}</div>
           <div className="layout-user-profile-header-email">{email}</div>
           {editLinkChildren}
+          <Dropdown.Divider className="header-divider" />
           {!_.isEmpty(headerChildren) && (
             <>
-              <Dropdown.Divider />
               {headerChildren}
+              <Dropdown.Divider />
             </>
           )}
         </Dropdown.Header>
         <div className="layout-user-profile-children-container">
           {!_.isEmpty(otherChildren) && (
             <>
-              <Dropdown.Divider />
               {otherChildren}
+              <Dropdown.Divider />
             </>
           )}
         </div>
-        <Dropdown.Divider />
         <form
           className="layout-user-profile-logout"
           method="post"

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -63,7 +63,6 @@
   .layout-user-profile-image
   > .orion.icon {
   font-size: 24px;
-  line-height: 16px;
 }
 
 /**

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -115,7 +115,7 @@
   @apply text-center;
 }
 
-.orion.layout .layout-user-profile .header .orion.divider {
+.orion.layout .layout-user-profile .header .orion.divider.header-divider {
   @apply mt-16;
 }
 

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -2,11 +2,16 @@
  * Dropdown trigger
  */
 .orion.layout .layout-user-profile {
-  @apply rounded px-8 py-4 whitespace-no-wrap;
+  @apply rounded px-8 py-4 whitespace-no-wrap flex-no-wrap;
 }
 
 .orion.layout .layout-user-profile-trigger {
-  @apply flex flex-col;
+  @apply flex flex-row items-center;
+  min-height: 34px;
+}
+
+.orion.layout .layout-user-profile-trigger-texts {
+  @apply flex flex-col justify-center ml-8;
 }
 
 .orion.layout .layout-user-profile:hover {
@@ -34,12 +39,31 @@
  * User Image
  */
 .orion.layout .layout-user-profile-image {
-  @apply flex items-center justify-center m-auto w-64 h-64 rounded-full overflow-hidden bg-gray-400;
+  @apply flex items-center justify-center rounded-full overflow-hidden bg-gray-400;
 }
 
 .orion.layout .layout-user-profile-image > .orion.icon {
   @apply text-gray-500;
+}
+
+.orion.layout .header .layout-user-profile-image {
+  @apply m-auto w-64 h-64;
+}
+
+.orion.layout .header .layout-user-profile-image > .orion.icon {
   font-size: 48px;
+}
+
+.orion.layout .layout-user-profile-trigger .layout-user-profile-image {
+  @apply w-32 h-32;
+}
+
+.orion.layout
+  .layout-user-profile-trigger
+  .layout-user-profile-image
+  > .orion.icon {
+  font-size: 24px;
+  line-height: 16px;
 }
 
 /**


### PR DESCRIPTION
Dois pequenos ajustes no UserProfile:
1. Adicionando a imagem do usuário no trigger do Menu
2. Quando não tínhamos o "HeaderItem", o espaçamento entre o header e o resto do menu ficava pequeno (pq eu aplicava o espaçamento em um divider que nao apareceria neste caso). Então reordenei os dividers pra o espaçamento aparecer a qualquer momento.

Antes:
![Screen Shot 2020-03-25 at 17 58 00](https://user-images.githubusercontent.com/9112403/77584809-3596af80-6ec2-11ea-9659-4371251dae84.png)


Agora:
![orion-user-profile-adjusts](https://user-images.githubusercontent.com/9112403/77584729-14ce5a00-6ec2-11ea-8a38-1fee796523af.gif)
