### PR TITLE
chore(tailwind): Add group-hover configuration

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -440,7 +440,7 @@ module.exports = {
     borderWidth: ['responsive'],
     boxShadow: ['responsive', 'hover', 'focus'],
     cursor: ['responsive'],
-    display: ['responsive'],
+    display: ['responsive', 'group-hover'],
     fill: ['responsive'],
     flex: ['responsive'],
     flexDirection: ['responsive'],


### PR DESCRIPTION
Hoje quando a quer fazer esta funcionalidade:
![2020-03-26 09 58 04](https://user-images.githubusercontent.com/1139664/77649273-57d31080-6f48-11ea-981f-4c745f46e75e.gif)

A gente pode fazer via React setando states no `onMouseOver` e `onMouseOut`.

Ou usando CSS:
```html
<tr className="tr">
  <td>
    <div className="actions">... buttons ...</div>
```
-------
```css
.actions { display: none }
tr:hover .actions { display: block }
```

A solução CSS quase sempre é a melhor, porque não precisa re-render, ou seja, mais performática.

Acontece que o tailwind tem o `group-hover`, que serve exatamente pra isso:
```html
<tr className="group">
  <td>
    <div className="hidden group-hover:block">
```

Mas pra isso a gente precisa habilitar na configuração ;-)

TOP?