### PR TITLE
fix(field-label-rule): Remove unnecessary field label rule

### DIFF
--- a/packages/orion/src/Form/Field/field.css
+++ b/packages/orion/src/Form/Field/field.css
@@ -65,11 +65,6 @@
   @apply pt-24;
 }
 
-/* Outside label */
-.orion.form .field label {
-  @apply block mb-8;
-}
-
 /* Error */
 .orion.form .field.error input,
 .orion.form .field.error .dropdown {


### PR DESCRIPTION
Esta regra tava aí a 1 ano, quando eu escrevi este componente pela primeira vez.

Cerca de 1 mês atrás Maíra adicionou uma regra mais específica e mais correta na linha 5:

```css
.orion.form .field > label { ... }
```

Esta aqui fez com fosse gerado efeito colateral em componentes que estivesse dentro de um Form.Field mas que fosse toggles, ex:
![image](https://user-images.githubusercontent.com/1139664/77679684-a943c580-6f71-11ea-97f4-4658a4c63154.png)

Por isto estou removendo esta.
