### PR TITLE
feature(table): Add selectable behavior

### DIFF
--- a/packages/orion/src/Table/Table.stories.js
+++ b/packages/orion/src/Table/Table.stories.js
@@ -1,11 +1,20 @@
 import _ from 'lodash'
 import React from 'react'
-import { number, object, radios, withKnobs } from '@storybook/addon-knobs'
+import {
+  number,
+  object,
+  radios,
+  boolean,
+  withKnobs
+} from '@storybook/addon-knobs'
 
 import { Table } from '../'
 
 const DEFAULT_HEADERS = ['Name', 'Project']
-const DEFAULT_DATA = [['Maíra', 'Insights'], ['Gileno', 'Accounts']]
+const DEFAULT_DATA = [
+  ['Maíra', 'Insights'],
+  ['Gileno', 'Accounts']
+]
 
 export default {
   title: 'Table',
@@ -15,8 +24,9 @@ export default {
 export const basic = () => {
   const headers = object('Headers', DEFAULT_HEADERS)
   const data = object('Data', DEFAULT_DATA)
+  const selectable = boolean('Selectable', false)
   return (
-    <Table>
+    <Table selectable={selectable}>
       <Table.Header>
         <Table.Row>
           {_.map(headers, (title, index) => (

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -22,7 +22,7 @@
 }
 
 .orion.table th:last-child {
-  @apply pr-24;
+  @apply pr-16;
 }
 
 .orion.table tr:first-child th:first-child {
@@ -108,4 +108,9 @@
 
 .orion.table.sortable th.sorted.descending > .inner-cell::after {
   transform: rotate(180deg);
+}
+
+/** Selectable **/
+.orion.table.selectable tbody > tr:hover {
+  @apply shadow-200;
 }

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -1,5 +1,7 @@
 .orion.table {
   @apply table-fixed text-left w-full;
+  border-collapse: separate;
+  border-spacing: 0 8px;
 }
 
 /** Header **/
@@ -60,7 +62,7 @@
 .orion.table tbody > tr > td > .inner-cell {
   @apply bg-white;
   @apply border-t-1 border-b-1 border-gray-900-8;
-  @apply px-12 mt-8;
+  @apply px-12;
   height: 54px;
 }
 

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -1,7 +1,5 @@
 .orion.table {
   @apply table-fixed text-left w-full;
-  border-collapse: separate;
-  border-spacing: 0 8px;
 }
 
 /** Header **/
@@ -62,7 +60,7 @@
 .orion.table tbody > tr > td > .inner-cell {
   @apply bg-white;
   @apply border-t-1 border-b-1 border-gray-900-8;
-  @apply px-12;
+  @apply px-12 mt-8;
   height: 54px;
 }
 
@@ -113,6 +111,6 @@
 }
 
 /** Selectable **/
-.orion.table.selectable tbody > tr:hover {
-  @apply shadow-200;
+.orion.table.selectable tbody > tr:hover > td > .inner-cell {
+  @apply bg-gray-900-4;
 }


### PR DESCRIPTION
Adicionando estilo para a prop `selectable
![2020-03-31 12 04 10](https://user-images.githubusercontent.com/1139664/78041972-cdbfe900-7347-11ea-9b76-23d9800c27e1.gif)
`:

```html
<table selectable ... />
```

**Update 31/03:2020: Mudar comportamento do hover**

Em vez do shadow, vamos só mudar o background. Alinhado com Bruno. 
Depois vamos pensar em uma solução para colocar o shadow...


![2020-03-31 12 04 10](https://user-images.githubusercontent.com/1139664/78042067-e9c38a80-7347-11ea-8c48-ff024ed35f94.gif)
