### PR TITLE
fix(dropdown): Fix search filtered text

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -38,6 +38,10 @@
   @apply invisible;
 }
 
+.orion.dropdown > .filtered.text {
+  visibility: hidden;
+}
+
 .orion.dropdown > .menu {
   @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full z-20;
   top: 100%;


### PR DESCRIPTION
Quando um dropdown é do tipo search, o que você estava buscando estava sobrescrevendo com o option selecionado... tipo assim:

![image](https://user-images.githubusercontent.com/1139664/79339865-e57a9e00-7eff-11ea-96f8-7f21ca635dd6.png)

OBS: Estou procurando por `Recife`, e o texto do option selecionado está sobrescrevendo.

Dei uma olhada no semantic, e nosso estilo estava faltando esta regra de CSS aqui.