### PR TITLE
feat(TagsInput): allows client to control the add values keys via prop

### DIFF
--- a/packages/orion/src/TagsInput/TagsInput.test.js
+++ b/packages/orion/src/TagsInput/TagsInput.test.js
@@ -14,7 +14,11 @@ it('should render initial values when defaultValue is given', () => {
 it('should trigger the onChange callback when the value is changed', () => {
   const mockOnChange = jest.fn()
   const { getByRole, getByText } = render(
-    <TagsInput onChange={mockOnChange} placeholder="placeholder" />
+    <TagsInput
+      onChange={mockOnChange}
+      placeholder="placeholder"
+      addValueKeys={['enter', 'comma', 'tab']}
+    />
   )
 
   const input = getByRole('combobox').childNodes[0]

--- a/packages/orion/src/TagsInput/TagsInput.test.js
+++ b/packages/orion/src/TagsInput/TagsInput.test.js
@@ -17,7 +17,11 @@ it('should trigger the onChange callback when the value is changed', () => {
     <TagsInput
       onChange={mockOnChange}
       placeholder="placeholder"
-      addValueKeys={['enter', 'comma', 'tab']}
+      addValueKeys={[
+        TagsInput.KeyboardKeys.ENTER,
+        TagsInput.KeyboardKeys.TAB,
+        TagsInput.KeyboardKeys.COMMA
+      ]}
     />
   )
 

--- a/packages/orion/src/TagsInput/index.js
+++ b/packages/orion/src/TagsInput/index.js
@@ -5,10 +5,16 @@ import PropTypes from 'prop-types'
 import keyboardKey from 'keyboard-key'
 import { Dropdown } from '@inloco/semantic-ui-react'
 
+const KeyboardKeys = {
+  ENTER: 'enter',
+  TAB: 'tab',
+  COMMA: 'comma'
+}
+
 const AddValueKeyCodes = {
-  enter: keyboardKey.Enter,
-  tab: keyboardKey.Tab,
-  comma: keyboardKey.Comma
+  [KeyboardKeys.ENTER]: keyboardKey.Enter,
+  [KeyboardKeys.TAB]: keyboardKey.Tab,
+  [KeyboardKeys.COMMA]: keyboardKey.Comma
 }
 
 const TagsInput = ({
@@ -114,11 +120,13 @@ TagsInput.propTypes = {
   onSearchChange: PropTypes.func,
   onBlur: PropTypes.func,
   selectOnBlur: PropTypes.bool,
-  addValueKeys: PropTypes.arrayOf(PropTypes.oneOf(_.keys(AddValueKeyCodes)))
+  addValueKeys: PropTypes.arrayOf(PropTypes.oneOf(_.values(KeyboardKeys)))
 }
 
 TagsInput.defaultProps = {
   addValueKeys: ['comma']
 }
+
+TagsInput.KeyboardKeys = KeyboardKeys
 
 export default TagsInput

--- a/packages/orion/src/TagsInput/index.js
+++ b/packages/orion/src/TagsInput/index.js
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types'
 import keyboardKey from 'keyboard-key'
 import { Dropdown } from '@inloco/semantic-ui-react'
 
-const ADD_VALUE_KEY_CODES = [
-  keyboardKey.Enter,
-  keyboardKey.Tab,
-  keyboardKey.Comma
-]
+const AddValueKeyCodes = {
+  enter: keyboardKey.Enter,
+  tab: keyboardKey.Tab,
+  comma: keyboardKey.Comma
+}
 
 const TagsInput = ({
   className,
@@ -18,12 +18,17 @@ const TagsInput = ({
   onBlur,
   onSearchChange,
   selectOnBlur,
+  addValueKeys,
   ...otherProps
 }) => {
   const [values, setValues] = useState(defaultValue || [])
   const [search, setSearch] = useState('')
   const [options, setOptions] = useState(
     _.map(defaultValue, value => ({ value, text: value }))
+  )
+  const addValuesKeyboardKeys = _.map(
+    addValueKeys,
+    key => AddValueKeyCodes[key]
   )
 
   const handleAddTagValue = func => {
@@ -82,11 +87,13 @@ const TagsInput = ({
         const { keyCode } = event
         const searchIsEmpty = _.size(_.trim(search)) === 0
 
-        if (_.includes(ADD_VALUE_KEY_CODES, keyCode) && !searchIsEmpty) {
+        if (_.includes(addValuesKeyboardKeys, keyCode) && !searchIsEmpty) {
           addCurrentValue()
         }
 
-        if (keyCode === keyboardKey.Tab) event.preventDefault()
+        if (keyCode === keyboardKey.Tab && _.includes(addValueKeys, 'tab')) {
+          event.preventDefault()
+        }
       }}
       onBlur={(event, data) => {
         if (search && selectOnBlur) {
@@ -106,7 +113,12 @@ TagsInput.propTypes = {
   onChange: PropTypes.func,
   onSearchChange: PropTypes.func,
   onBlur: PropTypes.func,
-  selectOnBlur: PropTypes.bool
+  selectOnBlur: PropTypes.bool,
+  addValueKeys: PropTypes.arrayOf(PropTypes.oneOf(_.keys(AddValueKeyCodes)))
+}
+
+TagsInput.defaultProps = {
+  addValueKeys: ['comma']
 }
 
 export default TagsInput

--- a/packages/orion/src/TagsInput/index.js
+++ b/packages/orion/src/TagsInput/index.js
@@ -97,9 +97,7 @@ const TagsInput = ({
           addCurrentValue()
         }
 
-        if (keyCode === keyboardKey.Tab && _.includes(addValueKeys, 'tab')) {
-          event.preventDefault()
-        }
+        shouldPreventDefault(keyCode, addValueKeys) && event.preventDefault()
       }}
       onBlur={(event, data) => {
         if (search && selectOnBlur) {
@@ -112,6 +110,11 @@ const TagsInput = ({
     />
   )
 }
+
+const shouldPreventDefault = (keyCode, addValueKeys) =>
+  (keyCode === keyboardKey.Tab && _.includes(addValueKeys, KeyboardKeys.TAB)) ||
+  (keyCode === keyboardKey.Enter &&
+    _.includes(addValueKeys, KeyboardKeys.ENTER))
 
 TagsInput.propTypes = {
   className: PropTypes.string,


### PR DESCRIPTION
o time de design ataca novamente
vitinho pediu p esse componente ficar só aceitando vírgulas (ao invés de vírgula, tab e enter) pra não perder tanto a navegação e acessibilidade.
aí eu preferi deixar controlável por prop, caso mude novamente.