### PR TITLE
fix(Form.Field): avoid hiding placeholder on focus

### DIFF
--- a/packages/orion/src/Form/Field/field.css
+++ b/packages/orion/src/Form/Field/field.css
@@ -46,12 +46,12 @@
   .field.floatingLabel
   label:not(:empty)
   + .datepicker-input-trigger
-  input::placeholder,
+  input:not(:focus)::placeholder,
 .orion.form
   .field.floatingLabel
   label:not(:empty)
   + .input
-  > input::placeholder {
+  > input:not(:focus)::placeholder {
   @apply transition-default;
   transition-property: color;
   color: transparent;


### PR DESCRIPTION
Estamos com um pequeno bug que faz o placeholder dos inputs em um Form ficarem transparentes. Essa regra está aí para os placeholders não se sobreporem às Labels que ficam dentro do input. Mas acontece que eles continuam transparentes mesmo quando a label sobre no `focus` do componente. 
Estou corrigindo para que essa regra não se aplique em caso de `:focus`. Agora está assim:
![orion-placeholder-dropdown-focus](https://user-images.githubusercontent.com/9112403/79485491-b6d9f180-7feb-11ea-9657-2d5aad8372e4.gif)


Entretanto, não pude corrigir o Dropdown de forma simples, pois a implementação do semântic substitui o "placeholder" (que é só um texto em uma div) pelo valor da opção selecionada ao abrir o Menu... Então deixei ele transparente ainda por enquanto. Se alguém tiver uma ideia de como podemos resolver isso, podemos tentar (talvez em um próximo PR se for mto complexo).
![orion-placeholder-dropdown](https://user-images.githubusercontent.com/9112403/79485569-d113cf80-7feb-11ea-8dbf-6cc7b5602f90.gif)
