### PR TITLE
feat(layoutUserProfile): adds object-cover to image

### DIFF
--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -42,6 +42,10 @@
   @apply flex items-center justify-center rounded-full overflow-hidden bg-gray-400;
 }
 
+.orion.layout .layout-user-profile-image > img {
+  @apply object-cover h-full w-full;
+}
+
 .orion.layout .layout-user-profile-image > .orion.icon {
   @apply text-gray-500;
 }
@@ -174,6 +178,10 @@
   @apply rounded-full w-40 h-40 mr-8 bg-gray-400 flex items-center justify-center overflow-hidden;
   grid-column: icon-start / icon-end;
   grid-row: span 2;
+}
+
+.orion.layout .user-profile-icon > img {
+  @apply h-full w-full object-cover;
 }
 
 /**


### PR DESCRIPTION
antes com uma foto paisagem:
<img width="337" alt="Screen Shot 2020-04-17 at 10 54 19 AM" src="https://user-images.githubusercontent.com/4022430/79576944-5ce43500-809a-11ea-93f8-928cbf69a069.png">


depois: 
<img width="353" alt="Screen Shot 2020-04-17 at 10 53 04 AM" src="https://user-images.githubusercontent.com/4022430/79577012-6ff70500-809a-11ea-94e3-0baae91cfec5.png">


