### PR TITLE
fix(notification-center): Fix shadow

### DIFF
--- a/packages/orion/src/NotificationCenter/notificationCenter.css
+++ b/packages/orion/src/NotificationCenter/notificationCenter.css
@@ -9,6 +9,6 @@
 }
 
 .orion-notification-center__toast.Toastify__toast {
-  @apply shadow-none p-0 m-0 mb-8 min-h-0 font-default;
+  @apply shadow-none p-0 m-0 mb-8 min-h-0 font-default overflow-visible;
   color: inherit;
 }


### PR DESCRIPTION
Bruno notou que as notificações do Notification Center estavam sem shadow:
![image](https://user-images.githubusercontent.com/1139664/79773021-3e36a600-8307-11ea-9674-c35ddbcd9477.png)

Notei que o `Toastr` estava colocando um `overflow: hidden`, o que impossibilitava com shadow de aparecer.

Sobrescrevi esta regra e agora aparece:
![image](https://user-images.githubusercontent.com/1139664/79773144-6d4d1780-8307-11ea-834c-2cf1afee917f.png)
