### PR TITLE
fix(drodown): Set max height

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -83,6 +83,10 @@
   @apply absolute bg-transparent outline-none;
 }
 
+.orion.search.dropdown .menu {
+  max-height: 250px;
+}
+
 .orion.dropdown.search.active input:focus + .text {
   @apply text-gray-800;
 }
@@ -159,7 +163,7 @@
 }
 
 .orion.dropdown.search.multiple > input {
-  @apply h-32 my-2 static w-32 max-w-full;
+  @apply h-32 my-2 static w-32  w-full;
 }
 
 .orion.dropdown.search.multiple.small > input {


### PR DESCRIPTION
Notei que se o nosso dropdown tiver muitos itens, ele não tem limite:

![image](https://user-images.githubusercontent.com/1139664/79788039-6087ee00-831e-11ea-9518-9dbd45b91c42.png)

Olhei no semantic, e copiei a regra que tem lá pra limitar o tamanho:

![image](https://user-images.githubusercontent.com/1139664/79788100-74335480-831e-11ea-8e03-8a44c3e051a1.png)
