### PR TITLE
fix(dropdown): Fix style when multiple

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -95,8 +95,12 @@
  * Multiple
  */
 
+.orion.dropdown.multiple {
+  @apply h-auto py-4;
+}
+
 .orion.dropdown.multiple .orion.label {
-  @apply mr-16;
+  @apply mr-16 my-2;
   margin-left: -8px;
 }
 
@@ -153,14 +157,6 @@
 /**
  * Search + Multiple
  */
-
-.orion.dropdown.search.multiple {
-  @apply h-auto py-4;
-}
-
-.orion.dropdown.search.multiple > .orion.label {
-  @apply my-2;
-}
 
 .orion.dropdown.search.multiple > input {
   @apply h-32 my-2 static w-32 max-w-full;


### PR DESCRIPTION
Notei que O dropdown `multiple` só tava estilizando correto quando também tinha a propriedade `search` ativada.

Com search:
![image](https://user-images.githubusercontent.com/1139664/81098679-19822700-8ee0-11ea-8148-8df6889372ff.png)

Sem search:
![image](https://user-images.githubusercontent.com/1139664/81098765-374f8c00-8ee0-11ea-932c-34a418333c0f.png)

O que eu fiz foi pegar os estilos de tag que estava aplicados a `.orion.dropdown.multiple.search` e subi para `.orion.dropdown.multiple`.

Assim resolveu.