### PR TITLE
Feature: checkbox instead of check on Dropdown.Item

### DIFF
--- a/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
+++ b/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
@@ -20,7 +20,7 @@
 }
 
 .orion.dropdown .menu > .item .description {
-  @apply mt-4 leading-14 text-gray-800 text-sm truncate;
+  @apply mt-4 leading-14 text-gray-800 text-sm;
 }
 
 .orion.dropdown .menu > .item .image {

--- a/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
+++ b/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
@@ -27,3 +27,11 @@
   @apply mr-8;
   max-width: 32px;
 }
+
+.orion.dropdown .menu > .item .checkbox {
+  @apply mr-16 hidden;
+}
+
+.orion.dropdown.multiple.keep-selected > .menu > .item .checkbox {
+  @apply block;
+}

--- a/packages/orion/src/Dropdown/DropdownItem/index.js
+++ b/packages/orion/src/Dropdown/DropdownItem/index.js
@@ -12,9 +12,10 @@ const DropdownItem = ({
   description,
   image,
   text,
-  active,
   ...otherProps
 }) => {
+  const { active } = otherProps
+
   if (!children) {
     children = (
       <div className="flex items-center">
@@ -37,9 +38,7 @@ const DropdownItem = ({
   }
 
   return (
-    <SemanticDropdown.Item active={active} {...otherProps}>
-      {children}
-    </SemanticDropdown.Item>
+    <SemanticDropdown.Item {...otherProps}>{children}</SemanticDropdown.Item>
   )
 }
 
@@ -48,8 +47,7 @@ DropdownItem.propTypes = {
   content: PropTypes.node,
   description: PropTypes.node,
   image: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
-  text: PropTypes.node,
-  active: PropTypes.bool
+  text: PropTypes.node
 }
 
 // Overriding original factory. See src/utils/factories.js for more details.

--- a/packages/orion/src/Dropdown/DropdownItem/index.js
+++ b/packages/orion/src/Dropdown/DropdownItem/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Dropdown as SemanticDropdown, Image } from '@inloco/semantic-ui-react'
 
+import Checkbox from '../../Checkbox'
 import { createShorthandFactory } from '../../utils/factories'
 
 const DropdownItem = ({
@@ -11,6 +12,7 @@ const DropdownItem = ({
   description,
   image,
   text,
+  active,
   ...otherProps
 }) => {
   if (!children) {
@@ -21,6 +23,9 @@ const DropdownItem = ({
             {Image.create(image, { autoGenerateKey: false })}
           </div>
         )}
+
+        <Checkbox checked={active} />
+
         <div className="flex-1 min-w-0">
           <div className="text">{_.isNil(content) ? text : content}</div>
           {!_.isNil(description) && (
@@ -30,8 +35,11 @@ const DropdownItem = ({
       </div>
     )
   }
+
   return (
-    <SemanticDropdown.Item {...otherProps}>{children}</SemanticDropdown.Item>
+    <SemanticDropdown.Item active={active} {...otherProps}>
+      {children}
+    </SemanticDropdown.Item>
   )
 }
 
@@ -40,7 +48,8 @@ DropdownItem.propTypes = {
   content: PropTypes.node,
   description: PropTypes.node,
   image: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
-  text: PropTypes.node
+  text: PropTypes.node,
+  active: PropTypes.bool
 }
 
 // Overriding original factory. See src/utils/factories.js for more details.

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -131,20 +131,6 @@
   @apply text-gray-800;
 }
 
-/**
- * Multiple + Keep selected
- */
-
-.orion.dropdown.multiple.keep-selected > .menu > .item.active {
-  @apply font-normal .relative;
-}
-
-.orion.dropdown.multiple.keep-selected > .menu > .item::after {
-  @apply absolute text-icon-md text-wave-500 leading-20;
-  top: calc(50% - 10px);
-  right: 16px;
-}
-
 .orion.dropdown.multiple.keep-selected.disabled > .menu {
   @apply hidden;
 }

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -145,11 +145,6 @@
   right: 16px;
 }
 
-.orion.dropdown.multiple.keep-selected > .menu > .item.active::after {
-  content: 'check';
-  font-family: 'Material Icons';
-}
-
 .orion.dropdown.multiple.keep-selected.disabled > .menu {
   @apply hidden;
 }


### PR DESCRIPTION
- No dropdown de seleção múltipla, usa checkbox ao invés de check;
- Remove a regra `truncate` no description. Agora, descrições longas recebem quebra de linha ao invés de ellipsis;
![dropdown3](https://user-images.githubusercontent.com/15937541/81330382-61d34d80-9076-11ea-9e1e-e7f5e4976ec0.gif)

A ideia é fazer base para esse componente aqui, que será implementado no `inloco-accounts`
![aa1](https://user-images.githubusercontent.com/15937541/81331111-7b28c980-9077-11ea-9a27-fb9a9b6b7bc1.jpg)

Tem um detalhe extra - no caso do Accounts, não é pra ter tags no input.
![aa2](https://user-images.githubusercontent.com/15937541/81331168-8da30300-9077-11ea-9b63-d69205124375.jpg)

Isso pode ser alcançável pela prop `renderLabel` do `Dropdown`. Como é um caso específico do Accounts, vou implementar isso por lá mesmo ao invés de generalizar a regra aqui.