### PR TITLE
Fix/opacity and shadows

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -192,9 +192,9 @@ module.exports = {
     },
     boxShadow: {
       100: '0 0 0 1px rgba(61, 62, 63, .16)',
-      200: '0 4px 6px 0px rgba(61, 62, 63, .16)',
-      300: '0 8px 10px 0px rgba(61, 62, 63, .16)',
-      400: '0 16px 24px 0px rgba(61, 62, 63, .16)',
+      200: '0 4px 6px -1px rgba(61, 62, 63, .16)',
+      300: '0 8px 10px -4px rgba(61, 62, 63, .16)',
+      400: '0 16px 24px -6px rgba(61, 62, 63, .16)',
       500: '0 24px 32px 0px rgba(61, 62, 63, .16)',
       default: '0 4px 16px -1px rgba(61, 62, 63, .16)',
       'field-hover': 'inset 0 0px 0px 1px rgba(61, 62, 63, .16)',

--- a/packages/orion/src/Dimmer/dimmer.css
+++ b/packages/orion/src/Dimmer/dimmer.css
@@ -10,7 +10,7 @@
 }
 
 .orion.dimmer.inverted {
-  background-color: rgba(0, 0, 0, 0.66);
+  background-color: rgba(0, 0, 0, 0.32);
 }
 
 /*******************************


### PR DESCRIPTION
Dois fixes neste PR:

Consertando a opacidade do Dimmer (fundo usado no Modal). Ele estava com a opacidade `.66` aqui, mas nos protótipos eram usadas opacidades `.33` e `.08`.
Bruno comentou que o valor correto deveria ser `.32`.

O outro fix é mais discreto, no raio do boxShadow. Nos protótipos, o "retangulo" da sombra é levemente menor que o do compoentente, esses valores variam de acordo com a profundidade:
![invision-shadows](https://user-images.githubusercontent.com/9112403/81412446-3bff8480-911a-11ea-9df3-fca28f713198.gif)
Então estou ajustando o raio das sombras (quarto argumento) para ficarem de acordo com o Invision.
