### PR TITLE
feature(filter): Add trigger prop

### DIFF
--- a/packages/orion/src/Filter/Filter.stories.js
+++ b/packages/orion/src/Filter/Filter.stories.js
@@ -88,6 +88,18 @@ export const withHover = () => (
   </Filter>
 )
 
+const ControlledFilter = () => {
+  const [value, setValue] = React.useState(['aqui'])
+  return (
+    <Filter trigger={<h1>{value}</h1>} {...actions} onApply={setValue}>
+      {filterProps => (
+        <FilterStoryInput {...filterProps} placeholder="Type your name" />
+      )}
+    </Filter>
+  )
+}
+export const withTrigger = () => <ControlledFilter />
+
 const FilterStoryInput = ({ onChange, value, ...otherProps }) => (
   <Input
     autoFocus

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -25,6 +25,7 @@ const Filter = ({
   onOpen,
   selectedText,
   text,
+  trigger,
   value: propValue,
   tooltipProps,
   ...otherProps
@@ -85,19 +86,23 @@ const Filter = ({
     active: open,
     selected: isSelected
   })
-  const trigger = (
+
+  const defaultTooltipTrigger = (
+    <Button className={triggerClasses} size={Sizes.SMALL}>
+      {isSelected ? selectedText(value) : text}
+      {isSelected && <FilterClearIcon onClick={handleClearIconClick} />}
+    </Button>
+  )
+
+  const tooltipTrigger = trigger || defaultTooltipTrigger
+
+  const tooltip = (
     <Tooltip
       disabled={_.isEmpty(_.get(tooltipProps, 'content'))}
       {...tooltipProps}
-      trigger={
-        <Button
-          className={triggerClasses}
-          onClick={handleTriggerClick}
-          size={Sizes.SMALL}>
-          {isSelected ? selectedText(value) : text}
-          {isSelected && <FilterClearIcon onClick={handleClearIconClick} />}
-        </Button>
-      }
+      trigger={React.cloneElement(tooltipTrigger, {
+        onClick: handleTriggerClick
+      })}
     />
   )
 
@@ -105,7 +110,7 @@ const Filter = ({
     <Popup
       className={cx(className, 'orion filter')}
       basic
-      trigger={trigger}
+      trigger={tooltip}
       open={open}
       {...otherProps}>
       <ClickOutside
@@ -159,9 +164,10 @@ Filter.propTypes = {
   onClear: PropTypes.func,
   onOpen: PropTypes.func,
   selectedText: PropTypes.func,
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
   value: PropTypes.any,
-  tooltipProps: PropTypes.object
+  tooltipProps: PropTypes.object,
+  trigger: PropTypes.node
 }
 
 Filter.defaultProps = {


### PR DESCRIPTION
O Filter atual tem um botão como trigger:
![image](https://user-images.githubusercontent.com/1139664/81433073-5fd2c280-913a-11ea-8366-3f69daf87faa.png)

Em um novo Invision que Bruno me passou, a gente tem um caso que o filtro é algo mais parecido com um Input:
![image](https://user-images.githubusercontent.com/1139664/81433209-927cbb00-913a-11ea-999f-f7369cef29b9.png)

O que este PR faz é permitir que a gente possa passar uma prop `trigger` para o `<Filter />`
