### PR TITLE
Feature/wizard auto scroll

### DIFF
--- a/packages/orion/src/Wizard/Wizard.stories.js
+++ b/packages/orion/src/Wizard/Wizard.stories.js
@@ -29,7 +29,7 @@ export const basic = () => {
       steps={array('Steps', ['Step 1', 'Step 2', 'Step 3'])}
       buttons={buttons}
       {...actions}
-      autoScrollOnStepChange={boolean('Auto-scroll', true)}>
+      scrollToTopOnStepChange={boolean('ScrollToTopOnStepChange', true)}>
       <div>
         Step 1 Content
         <div className="mb-24">

--- a/packages/orion/src/Wizard/Wizard.stories.js
+++ b/packages/orion/src/Wizard/Wizard.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import { array, withKnobs } from '@storybook/addon-knobs'
+import { array, boolean, withKnobs } from '@storybook/addon-knobs'
 
 import { Button, Wizard } from '../'
 
@@ -28,9 +28,28 @@ export const basic = () => {
     <Wizard
       steps={array('Steps', ['Step 1', 'Step 2', 'Step 3'])}
       buttons={buttons}
-      {...actions}>
+      {...actions}
+      autoScrollOnStepChange={boolean('Auto-scroll', false)}>
       <div>
         Step 1 Content
+        <div className="mb-24">
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Nemo veniam
+          at, maxime adipisci sunt non voluptatum architecto quisquam sapiente
+          eligendi natus nisi totam, incidunt, asperiores minus alias
+          accusantium! Quis, aliquid.
+        </div>
+        <div className="mb-24">
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Nemo veniam
+          at, maxime adipisci sunt non voluptatum architecto quisquam sapiente
+          eligendi natus nisi totam, incidunt, asperiores minus alias
+          accusantium! Quis, aliquid.
+        </div>
+        <div className="mb-24">
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Nemo veniam
+          at, maxime adipisci sunt non voluptatum architecto quisquam sapiente
+          eligendi natus nisi totam, incidunt, asperiores minus alias
+          accusantium! Quis, aliquid.
+        </div>
         <div>
           Lorem, ipsum dolor sit amet consectetur adipisicing elit. Nemo veniam
           at, maxime adipisci sunt non voluptatum architecto quisquam sapiente
@@ -40,6 +59,24 @@ export const basic = () => {
       </div>
       <div>
         Step 2 Content
+        <div className="mb-24">
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Nemo veniam
+          at, maxime adipisci sunt non voluptatum architecto quisquam sapiente
+          eligendi natus nisi totam, incidunt, asperiores minus alias
+          accusantium! Quis, aliquid.
+        </div>
+        <div className="mb-24">
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Nemo veniam
+          at, maxime adipisci sunt non voluptatum architecto quisquam sapiente
+          eligendi natus nisi totam, incidunt, asperiores minus alias
+          accusantium! Quis, aliquid.
+        </div>
+        <div className="mb-24">
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Nemo veniam
+          at, maxime adipisci sunt non voluptatum architecto quisquam sapiente
+          eligendi natus nisi totam, incidunt, asperiores minus alias
+          accusantium! Quis, aliquid.
+        </div>
         <div>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quia quidem
           quae ex deserunt commodi dolor vel rerum optio quos sunt quibusdam

--- a/packages/orion/src/Wizard/Wizard.stories.js
+++ b/packages/orion/src/Wizard/Wizard.stories.js
@@ -29,7 +29,7 @@ export const basic = () => {
       steps={array('Steps', ['Step 1', 'Step 2', 'Step 3'])}
       buttons={buttons}
       {...actions}
-      autoScrollOnStepChange={boolean('Auto-scroll', false)}>
+      autoScrollOnStepChange={boolean('Auto-scroll', true)}>
       <div>
         Step 1 Content
         <div className="mb-24">

--- a/packages/orion/src/Wizard/index.js
+++ b/packages/orion/src/Wizard/index.js
@@ -28,7 +28,7 @@ const Wizard = ({
 
   useEffect(() => {
     autoScrollOnStepChange && scrollToTop()
-  }, [currentStepState])
+  }, [autoScrollOnStepChange, currentStepState])
 
   return (
     <div className={cx('orion wizard', className)}>

--- a/packages/orion/src/Wizard/index.js
+++ b/packages/orion/src/Wizard/index.js
@@ -1,10 +1,11 @@
 import cx from 'classnames'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import StepsNav from '../StepsNav'
 import WizardControls, { WizardButtons } from './WizardControls'
+import { scrollToTop } from '../utils/scroll'
 
 const Wizard = ({
   children,
@@ -12,7 +13,8 @@ const Wizard = ({
   currentStepIndex: currentStepProp,
   onStepIndexChange,
   steps,
-  buttons
+  buttons,
+  autoScrollOnStepChange
 }) => {
   const [currentStepState, setCurrentStepState] = useState(currentStepProp || 0)
   const currentStepIndex = _.isNil(currentStepProp)
@@ -23,6 +25,10 @@ const Wizard = ({
     setCurrentStepState(newStep)
     onStepIndexChange(newStep)
   }
+
+  useEffect(() => {
+    autoScrollOnStepChange && scrollToTop()
+  }, [currentStepState])
 
   return (
     <div className={cx('orion wizard', className)}>
@@ -47,7 +53,8 @@ Wizard.propTypes = {
   currentStepIndex: PropTypes.number,
   onStepIndexChange: PropTypes.func,
   steps: PropTypes.arrayOf(PropTypes.string).isRequired,
-  buttons: PropTypes.object
+  buttons: PropTypes.object,
+  autoScrollOnStepChange: PropTypes.bool
 }
 
 Wizard.defaultProps = {
@@ -56,7 +63,8 @@ Wizard.defaultProps = {
     [WizardButtons.NEXT]: 'Next',
     [WizardButtons.FINISH]: 'Finish'
   },
-  onStepIndexChange: () => {}
+  onStepIndexChange: () => {},
+  autoScrollOnStepChange: false
 }
 
 Wizard.Buttons = WizardButtons

--- a/packages/orion/src/Wizard/index.js
+++ b/packages/orion/src/Wizard/index.js
@@ -64,7 +64,7 @@ Wizard.defaultProps = {
     [WizardButtons.FINISH]: 'Finish'
   },
   onStepIndexChange: () => {},
-  autoScrollOnStepChange: false
+  autoScrollOnStepChange: true
 }
 
 Wizard.Buttons = WizardButtons

--- a/packages/orion/src/Wizard/index.js
+++ b/packages/orion/src/Wizard/index.js
@@ -14,7 +14,7 @@ const Wizard = ({
   onStepIndexChange,
   steps,
   buttons,
-  autoScrollOnStepChange
+  scrollToTopOnStepChange
 }) => {
   const [currentStepState, setCurrentStepState] = useState(currentStepProp || 0)
   const currentStepIndex = _.isNil(currentStepProp)
@@ -27,8 +27,8 @@ const Wizard = ({
   }
 
   useEffect(() => {
-    autoScrollOnStepChange && scrollToTop()
-  }, [autoScrollOnStepChange, currentStepState])
+    scrollToTopOnStepChange && scrollToTop()
+  }, [scrollToTopOnStepChange, currentStepState])
 
   return (
     <div className={cx('orion wizard', className)}>
@@ -54,7 +54,7 @@ Wizard.propTypes = {
   onStepIndexChange: PropTypes.func,
   steps: PropTypes.arrayOf(PropTypes.string).isRequired,
   buttons: PropTypes.object,
-  autoScrollOnStepChange: PropTypes.bool
+  scrollToTopOnStepChange: PropTypes.bool
 }
 
 Wizard.defaultProps = {
@@ -64,7 +64,7 @@ Wizard.defaultProps = {
     [WizardButtons.FINISH]: 'Finish'
   },
   onStepIndexChange: () => {},
-  autoScrollOnStepChange: true
+  scrollToTopOnStepChange: true
 }
 
 Wizard.Buttons = WizardButtons

--- a/packages/orion/src/utils/scroll.js
+++ b/packages/orion/src/utils/scroll.js
@@ -1,0 +1,1 @@
+export const scrollToTop = () => window.scrollTo(0, 0)


### PR DESCRIPTION
Quando o conteúdo do wizard era grande o suficiente para ter um scroll, o scroll continuava na mesma posição ao mudar de passo ao invés de ir pro topo da página. Isso tornava a experiência ruim. Adicionei uma prop para que o scroll aconteça.

Dúvida: acham que esse scroll automático deveria ser o comportamento padrão? Me parece mais correto. Se sim, eu mudo o valor default pra `true`.

![2020-05-07 17 04 17](https://user-images.githubusercontent.com/28961613/81485308-853afb80-9222-11ea-8d19-aa9086729b63.gif)

Com o scroll automático:
![2020-05-09 18 18 01](https://user-images.githubusercontent.com/28961613/81485300-6b99b400-9222-11ea-9c1d-0dfe68c07e94.gif)
