### PR TITLE
fix(Tour): setCurrentStep only after welcomeModal

### DIFF
--- a/packages/orion/src/Tour/index.js
+++ b/packages/orion/src/Tour/index.js
@@ -31,7 +31,7 @@ function Tour({
   onFinish,
   onDismiss
 }) {
-  const [currentStep, setCurrentStep] = useState(0)
+  const [currentStep, setCurrentStep] = useState(welcomeModal ? null : 0)
   const [openTour, setOpenTour] = useState(!welcomeModal)
   const [openModal, setOpenModal] = useState(!!welcomeModal)
   const tourSteps = useMemo(() => parseSteps(steps), [steps])
@@ -70,6 +70,7 @@ function Tour({
         onContinue={() => {
           setOpenModal(false)
           setOpenTour(true)
+          setCurrentStep(0)
         }}
         {...welcomeModal}
       />

--- a/packages/orion/src/Tour/utils.js
+++ b/packages/orion/src/Tour/utils.js
@@ -132,7 +132,7 @@ export function useBadgePosition(steps, currentStep) {
   useEffect(() => {
     updateBadgePosition()
     return () => setbadgePosition(null)
-  }, [currentStep, updateBadgePosition])
+  }, [steps, currentStep, updateBadgePosition])
 
   useEffect(() => {
     const debouncedUpdateBadgePosition = _.debounce(updateBadgePosition, 100)

--- a/packages/orion/src/Tour/utils.js
+++ b/packages/orion/src/Tour/utils.js
@@ -132,7 +132,7 @@ export function useBadgePosition(steps, currentStep) {
   useEffect(() => {
     updateBadgePosition()
     return () => setbadgePosition(null)
-  }, [steps, currentStep, updateBadgePosition])
+  }, [updateBadgePosition])
 
   useEffect(() => {
     const debouncedUpdateBadgePosition = _.debounce(updateBadgePosition, 100)


### PR DESCRIPTION
Tinha um pequeno bug no caso em que o primeiro passo era um ancorado (sem seletor) e havia um Modal de welcome (que é exatamente o caso da Tour da Home :facepalm:).

Ao chamar o `useBadgePosition`, estou passando o `currentStep` para procurar a posição da Badge do passo atual. Como estava inicializando o `currentStep` com zero, no primeiro render já será procurando a posição da primeira Badge. Porém, se esse primeiro passo for um com âncora, no qual coloquei para renderizar um elemento placeholder, tal elemento não está renderizado ainda, então a posição da badge fica `null`. Ao passar do modal para o Tour per se, como o `currentStep` permanece zero, o `useEffect` do `useBadgePosition` não vai atualizar a posição. Fazendo com que no primeiro passo, fique sem badge até redimensionar a tela ou ir para o proximo passo.
![Screen Shot 2020-05-12 at 09 26 09](https://user-images.githubusercontent.com/9112403/81691076-a1ad8280-9432-11ea-88cb-280735862dbc.png)


Estou corrigindo para inicializar o `currentStep` com `null` caso haja um `welcomeModal` no Tour