### PR TITLE
Fix/tour anchors render

### DIFF
--- a/packages/orion/src/Tour/index.js
+++ b/packages/orion/src/Tour/index.js
@@ -74,6 +74,19 @@ function Tour({
         }}
         {...welcomeModal}
       />
+      <Portal open={openTour}>
+        <div className="orion-tour-anchors">
+          {tourSteps.map(({ anchor }, i) =>
+            anchor ? (
+              <Anchor
+                key={i}
+                className={getAnchorClassName(i)}
+                position={anchor}
+              />
+            ) : null
+          )}
+        </div>
+      </Portal>
       <Reactour
         className={className}
         rounded={tourSteps[currentStep]?.radius || DEFAULT_RADIUS}
@@ -98,18 +111,7 @@ function Tour({
         highlightedMaskClassName="orion-tour-highlight-mask"
         disableInteraction>
         <Portal open>
-          <div className="orion-tour-portal">
-            <Badge position={badgePosition} />
-            {tourSteps.map(({ anchor }, i) =>
-              anchor ? (
-                <Anchor
-                  key={i}
-                  className={getAnchorClassName(i)}
-                  position={anchor}
-                />
-              ) : null
-            )}
-          </div>
+          <Badge position={badgePosition} />
         </Portal>
         <div className="orion-tour-controls">
           <ul className="space-x-8">

--- a/packages/orion/src/Tour/utils.js
+++ b/packages/orion/src/Tour/utils.js
@@ -112,13 +112,10 @@ function calculateBadgePosition(node, padding, position, distance) {
 export function useBadgePosition(steps, currentStep) {
   const [badgePosition, setbadgePosition] = useState(null)
 
-  console.log({ badgePosition })
-
   const updateBadgePosition = useCallback(() => {
     const selector = steps[currentStep]?.selector
 
     const element = document.querySelector(selector)
-    console.log({ element })
     if (!element) return null
 
     const { padding, badgePosition, badgeDistance, anchor } = steps[currentStep]
@@ -133,7 +130,6 @@ export function useBadgePosition(steps, currentStep) {
   }, [steps, currentStep])
 
   useEffect(() => {
-    console.log('Effect')
     updateBadgePosition()
     return () => setbadgePosition(null)
   }, [updateBadgePosition])

--- a/packages/orion/src/Tour/utils.js
+++ b/packages/orion/src/Tour/utils.js
@@ -19,7 +19,7 @@ export const BadgePosition = {
   BOTTOM_RIGHT: 'bottom right'
 }
 
-export const getAnchorClassName = key => `react-tour-step-${key}`
+export const getAnchorClassName = key => `orion-tour-step-${key}`
 
 export function parseSteps(steps) {
   return steps.map(
@@ -112,10 +112,13 @@ function calculateBadgePosition(node, padding, position, distance) {
 export function useBadgePosition(steps, currentStep) {
   const [badgePosition, setbadgePosition] = useState(null)
 
+  console.log({ badgePosition })
+
   const updateBadgePosition = useCallback(() => {
     const selector = steps[currentStep]?.selector
 
     const element = document.querySelector(selector)
+    console.log({ element })
     if (!element) return null
 
     const { padding, badgePosition, badgeDistance, anchor } = steps[currentStep]
@@ -130,6 +133,7 @@ export function useBadgePosition(steps, currentStep) {
   }, [steps, currentStep])
 
   useEffect(() => {
+    console.log('Effect')
     updateBadgePosition()
     return () => setbadgePosition(null)
   }, [updateBadgePosition])


### PR DESCRIPTION
Outro bug, gente, parecido com o anterior.
Eu estava renderizando os `Anchor` junto com os steps do reactour. Porém, se o primeiro passo já for um anchor, ele não vai ter sido renderizado a tempo de o passo pegar, então é necessário ter renderizado antes. Então estou passando um Portal só com as âncoras para fora do Reactour. 
Isso funciona pq o Tour é renderizado em dois renders, daí os passos só buscam o seletor no segundo render.