### PR TITLE
Fix: search results z-index

### DIFF
--- a/packages/orion/src/Search/search.css
+++ b/packages/orion/src/Search/search.css
@@ -25,7 +25,7 @@
 }
 
 .orion.search.active .results {
-  @apply block rounded;
+  @apply block rounded z-50;
 }
 
 .orion.search.active .results > .message.empty {


### PR DESCRIPTION
Estranhamente, só acontece com o botão quando ele tá disabled, ou seja, quando a opacidade dele é menor que 1. Isso tá me levando a pensar que existe uma solução melhor, mas não consegui pensar em nenhuma :thinking: 

**O BUG** 
![Screenshot from 2020-05-15 08-32-38](https://user-images.githubusercontent.com/15937541/82046424-3b6d6d80-9687-11ea-92d7-0be97c62caa7.png)

**FIXED**
![Screenshot from 2020-05-15 08-32-50](https://user-images.githubusercontent.com/15937541/82046438-40cab800-9687-11ea-96b0-2537ff45f15b.png)
