### PR TITLE
fix(dropdown): adds css styles for divider

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -43,7 +43,7 @@
 }
 
 .orion.dropdown > .menu {
-  @apply absolute bg-white border border-gray-900-16 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full z-20;
+  @apply absolute bg-white border border-gray-900-8 hidden mt-8 shadow-200 left-0 overflow-y-auto w-full z-20;
   top: 100%;
 }
 
@@ -222,4 +222,12 @@
 .orion.dropdown.warning.selection:active,
 .orion.dropdown.warning.selection:focus {
   @apply shadow-warning-field-active;
+}
+
+/**
+ * Divider
+ */
+
+.orion.dropdown .menu > .divider {
+  @apply border-t border-gray-900-16;
 }


### PR DESCRIPTION
tem 2 ajustes nesse PR:
i) adicionei o css do divider, que nunca existiu, aí o dropdown de produtos tava sem aparecer
ii) mudei a borda do menu de dropdown, que tava gray-900-16, só que, pelo protótipo, ela é mais clara que o divider (que é gray-900-16 tb), aí eu diminuí pra gray-900-8.

<img width="628" alt="Screen Shot 2020-05-20 at 7 03 16 PM" src="https://user-images.githubusercontent.com/4022430/82502244-146ecb80-9acd-11ea-93e5-d40354f82daa.png">

protótipo: https://inloco.invisionapp.com/d/main?origin=v7#/console/19947146/417807047/preview?scrollOffset=1389