### PR TITLE
feature(card): Add Icon and center alignment

### DIFF
--- a/packages/orion/src/Card/Card.stories.js
+++ b/packages/orion/src/Card/Card.stories.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import { boolean, text, withKnobs } from '@storybook/addon-knobs/react'
-import cx from 'classnames'
 
-import { Button, Card, Icon } from '../'
+import { Button, Card } from '../'
 
 export default {
   title: 'Card',
@@ -12,13 +11,39 @@ export default {
 export const basic = () => {
   const header = text('Header', 'Header Title')
   const mainContent = text('Main content', 'Card content here')
+  const center = boolean('Center', false)
+  const disabled = boolean('Disabled', false)
+  const readOnly = boolean('Read Only', false)
+  const icon = text('Icon', 'home')
+  return (
+    <Card
+      center={center}
+      fluid={boolean('Fluid', false)}
+      disabled={disabled}
+      icon={icon}
+      readOnly={readOnly}>
+      <Card.Content>
+        <Card.Header>{header}</Card.Header>
+        {mainContent}
+      </Card.Content>
+    </Card>
+  )
+}
+
+export const withFooter = () => {
+  const center = boolean('Center', false)
+  const header = text('Header', 'Header Title')
+  const icon = text('Icon', 'map')
+  const mainContent = text('Main content', 'Card content here')
   const extra = text('Footer', '')
   const disabled = boolean('Disabled', false)
   const readOnly = boolean('Read Only', false)
   return (
     <Card
+      center={center}
       fluid={boolean('Fluid', false)}
       disabled={disabled}
+      icon={icon}
       readOnly={readOnly}>
       <Card.Content>
         <Card.Header>{header}</Card.Header>
@@ -39,25 +64,23 @@ export const basic = () => {
 }
 
 export const selectable = () => {
-  const title = text('Title', 'Integrate SDK')
-  const selected = boolean(`Selected`, false)
+  const center = boolean('Center', false)
   const disabled = boolean('Disabled', false)
+  const icon = text('Icon', 'code')
   const readOnly = boolean('Read Only', false)
+  const selected = boolean(`Selected`, false)
+  const title = text('Title', 'Integrate SDK')
   return (
     <Card
-      fluid={boolean('Fluid', false)}
+      center={center}
       disabled={disabled}
+      fluid={boolean('Fluid', false)}
+      icon={icon}
       readOnly={readOnly}
       selectable
       selected={selected}
       withCheckbox={boolean('With Checkbox', false)}>
-      <Card.Content className="flex flex-col items-center">
-        <Icon
-          name="code"
-          className={cx('text-gray-700', { 'text-wave-500': selected })}
-        />
-        <div className="mt-8">{title}</div>
-      </Card.Content>
+      <Card.Content>{title}</Card.Content>
     </Card>
   )
 }

--- a/packages/orion/src/Card/card.css
+++ b/packages/orion/src/Card/card.css
@@ -1,3 +1,6 @@
+/***
+**** Basic Rules
+***/
 .orion.card {
   @apply relative bg-white border-1 border-gray-900-8 inline-block rounded;
   @apply inline-flex flex-col;
@@ -8,19 +11,57 @@
 }
 
 .orion.card .header {
-  @apply font-display mb-24 text-lg text-gray-800;
+  @apply mb-8 font-medium;
 }
 
 .orion.card > .content {
-  @apply flex-grow p-24 text-gray-900;
+  @apply flex-grow p-16 text-gray-900;
 }
 
 .orion.card > .extra {
-  @apply flex flex-grow-0 flex-shrink-0 items-center justify-end px-24 py-8;
-  @apply border-t-1 border-gray-900-16;
+  @apply flex flex-grow-0 flex-shrink-0 items-center justify-end px-16 py-8;
+  @apply border-t-1 border-gray-900-16 w-full;
 }
 
-/* Selectable and selected */
+/***
+**** Alignment
+***/
+.orion.card.center {
+  @apply items-center;
+}
+
+.orion.card.center > .content,
+.orion.card.center.has-icon .header {
+  @apply text-center;
+}
+
+/* Alignment with icon */
+.orion.card.center.has-icon > .content {
+  @apply pt-8;
+}
+
+.orion.card:not(.center).has-icon > .content:not(.extra) {
+  margin-left: 28px;
+}
+
+/***
+**** Card Icon
+***/
+.orion.card > .card-icon {
+  @apply m-16 mb-0;
+}
+
+.orion.card:not(.center) > .card-icon {
+  @apply absolute top-0 left-0;
+}
+
+.orion.card.selectable.selected:not(.disabled):not(.read-only) > .card-icon {
+  @apply text-wave-500;
+}
+
+/***
+**** Selectable
+***/
 
 .orion.card.selectable {
   @apply shadow-200 cursor-pointer transition-default;
@@ -48,7 +89,9 @@
   @apply absolute left-0 top-0 m-8;
 }
 
-/* Disabled */
+/***
+**** Disabled
+***/
 .orion.card.disabled,
 .orion.card.selectable.disabled,
 .orion.card.selectable.disabled:hover,
@@ -57,7 +100,9 @@
   @apply border-gray-900-16 bg-gray-900-8 cursor-default opacity-64 shadow-none;
 }
 
-/* Read Only */
+/***
+**** Read Only
+***/
 .orion.card.read-only,
 .orion.card.selectable.read-only,
 .orion.card.selectable.read-only:hover,

--- a/packages/orion/src/Card/index.tsx
+++ b/packages/orion/src/Card/index.tsx
@@ -1,11 +1,14 @@
 import cx from 'classnames'
 import React from 'react'
 import { Checkbox, Card as SemanticCard } from '@inloco/semantic-ui-react'
+import Icon from '../Icon'
 
 const Card: CardComponent<CardProps> = ({
+  center,
   children,
   className,
   disabled,
+  icon,
   readOnly,
   selectable,
   selected,
@@ -13,7 +16,9 @@ const Card: CardComponent<CardProps> = ({
   ...otherProps
 }) => {
   const classes = cx(className, {
+    center: center,
     disabled,
+    'has-icon': !!icon,
     'read-only': readOnly,
     selectable,
     selected: selectable && selected
@@ -24,15 +29,18 @@ const Card: CardComponent<CardProps> = ({
       {selectable && withCheckbox && (
         <Checkbox checked={selected} disabled={disabled} readOnly />
       )}
+      {icon && <Icon name={icon} className="card-icon" />}
       {children}
     </SemanticCard>
   )
 }
 
 type CardProps = {
+  center?: boolean
   children?: React.ReactNode
   className?: string
   disabled?: boolean
+  icon?: string
   readOnly?: boolean
   selectable?: boolean
   selected?: boolean


### PR DESCRIPTION
Este PR contempla:
* O padding do Card passa de 24px pra 16px;
* O `<Card.Header />` só tem um `font-weight: 500` de diferença pra um texto normal.
* Possibilidade de adicionar um ícone no componente Card.
* Possibilidade de alinhar o conteúdo centralizado.

Este dois últimos são um pouco opiniativos, porque hoje podemos fazer o que quiser com o conteúdo do Card:
```jsx
  <Card>
    <Card.Content>Todo poder ao seu alcance</Card.Content>
  </Card>
```

Mas conversando com Bruno, ele disse que o Card poderia ter um ícone, e ele poderia mudar de cor dependendo do estado(selected), e também o alinhamento. Ex:

Mudando de cor no estado selected:
![image](https://user-images.githubusercontent.com/1139664/82672314-94ed1380-9c16-11ea-86c3-de25e9522aed.png)

Mudando o alinhamento:
![image](https://user-images.githubusercontent.com/1139664/82672871-53a93380-9c17-11ea-93e4-1d8254731e8a.png)

![image](https://user-images.githubusercontent.com/1139664/82672527-d7165500-9c16-11ea-9bba-2ec711d54772.png)

Baseado neste comportamento padrão, eu resolvi trazer este comportamento pro Card como props adicionais. Se você passar o `icon` como prop do card, ele vai automaticamente mudar de color no selected, além de alinhar corretamente ao conteúdo:

![2020-05-22 10 34 03](https://user-images.githubusercontent.com/1139664/82673204-dcc06a80-9c17-11ea-90fb-89e1d4d36e5f.gif)

