### PR TITLE
fix(placeholder): Fix color for non orion inputs

### DIFF
--- a/packages/atomic-bomb/css/base.css
+++ b/packages/atomic-bomb/css/base.css
@@ -26,7 +26,9 @@ a:active {
   @apply text-wave-800;
 }
 
-::placeholder {
+::placeholder,
+input::placeholder,
+textarea::placeholder {
   @apply text-gray-800 opacity-100;
 }
 


### PR DESCRIPTION
Tem alguns inputs não Orion no `inloco` que estavam com a cor do placeholder diferente. Notei que esta cor estava sendo passado pelo tailwind base class.

Aí tô sobrescrevendo, pra usar a mesma cor dos inputs do Orion.

A gente usa inputs que não são Orion em casos especiais, como o Emoji picker.
