### PR TITLE
feature(Pagination): Add size prop

### DIFF
--- a/packages/orion/src/Pagination/Pagination.stories.js
+++ b/packages/orion/src/Pagination/Pagination.stories.js
@@ -2,7 +2,9 @@ import React from 'react'
 import { boolean, object, number, withKnobs } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 
+import { Sizes } from '../utils/sizes'
 import { Pagination } from '../'
+import { sizeKnob } from '../utils/stories'
 
 const actions = {
   onPageChange: action('onPageChange'),
@@ -28,6 +30,7 @@ export const basic = () => (
       results: 'results'
     })}
     loading={boolean('loading', false)}
+    size={sizeKnob(Sizes.DEFAULT)}
     {...actions}
   />
 )
@@ -43,6 +46,7 @@ export const disabled = () => (
       of: 'of',
       results: 'results'
     })}
+    size={sizeKnob(Sizes.DEFAULT)}
     {...actions}
   />
 )
@@ -58,6 +62,7 @@ export const alignButtonsLeft = () => (
       of: 'of',
       results: 'results'
     })}
+    size={sizeKnob(Sizes.DEFAULT)}
     {...actions}
   />
 )

--- a/packages/orion/src/Pagination/index.js
+++ b/packages/orion/src/Pagination/index.js
@@ -3,28 +3,31 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { Placeholder } from '@inloco/semantic-ui-react'
 
+import { Sizes, sizePropType } from '../utils/sizes'
 import Button from '../Button'
 
 const ACTIVE_PAGE_MIN = 1
 
 const Pagination = ({
   activePage,
+  alignButtonsLeft,
   className,
   disabled,
   i18n,
+  loading,
   onPageChange,
   onPrevPage,
   onNextPage,
   pageSize,
-  alignButtonsLeft,
   totalItems,
-  loading,
+  size,
   ...otherProps
 }) => {
   if (!loading && pageSize < 1) return null
 
   const orionPaginationClasses = cx('orion-pagination', className, {
-    'orion-pagination-align-buttons-left': alignButtonsLeft
+    'orion-pagination-align-buttons-left': alignButtonsLeft,
+    'orion-pagination-size-small': size === Sizes.SMALL
   })
 
   if (loading) {
@@ -99,28 +102,30 @@ const Pagination = ({
 
 Pagination.propTypes = {
   activePage: PropTypes.number,
+  alignButtonsLeft: PropTypes.bool,
+  className: PropTypes.string,
   disabled: PropTypes.bool,
+  loading: PropTypes.bool,
+  i18n: PropTypes.shape({
+    of: PropTypes.string,
+    results: PropTypes.string
+  }),
   onPageChange: PropTypes.func,
   onPrevPage: PropTypes.func,
   onNextPage: PropTypes.func,
   pageSize: PropTypes.number,
-  alignButtonsLeft: PropTypes.bool,
   totalItems: PropTypes.number.isRequired,
-  loading: PropTypes.bool,
-  className: PropTypes.string,
-  i18n: PropTypes.shape({
-    of: PropTypes.string,
-    results: PropTypes.string
-  })
+  size: sizePropType
 }
 
 Pagination.defaultProps = {
   activePage: 1,
-  pageSize: 10,
   i18n: {
     of: 'of',
     results: 'results'
-  }
+  },
+  pageSize: 10,
+  size: Sizes.DEFAULT
 }
 
 export default Pagination

--- a/packages/orion/src/Pagination/pagination.css
+++ b/packages/orion/src/Pagination/pagination.css
@@ -34,3 +34,11 @@
 .orion-pagination-actions .orion.button + .orion.button {
   @apply ml-4;
 }
+
+.orion-pagination-size-small {
+  @apply min-h-32;
+}
+
+.orion-pagination-size-small .orion-pagination-actions .orion.button {
+  @apply w-32 h-32;
+}


### PR DESCRIPTION
Bruno me passou um protótipo em que a paginação aparecendo dentro de um Card. 

Neste tipo de uso, ele pediu pra que os botões de Next e Previous fossem um pouco menores.

Por isso estou adicionando a prop `size` para o Pagination.

Print do protótipo:
![image](https://user-images.githubusercontent.com/1139664/83416005-67625000-a3f6-11ea-8da8-dc4cb1c83802.png)

Como ficou:
![2020-06-01 10 55 52](https://user-images.githubusercontent.com/1139664/83416078-819c2e00-a3f6-11ea-8d61-750e01f3f2cf.gif)


