### PR TITLE
feat(ZoomImage): add modalClassName prop

### DIFF
--- a/packages/orion/src/ZoomImage/ImageModal.tsx
+++ b/packages/orion/src/ZoomImage/ImageModal.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import cx from 'classnames'
 import { Modal } from '@inloco/semantic-ui-react'
 
 import { Button } from '..'
@@ -6,10 +7,11 @@ import { Button } from '..'
 const ImageModal: FunctionComponent<ImageModalProps> = ({
   src,
   alt,
+  className,
   onClose
 }) => {
   return (
-    <Modal open className="orion-zoom-image-modal">
+    <Modal open className={cx(className, 'orion-zoom-image-modal')}>
       <Button subtle secondary icon="close" onClick={onClose} />
       <div className="image-wrapper">
         <img src={src} alt={alt} />
@@ -21,6 +23,7 @@ const ImageModal: FunctionComponent<ImageModalProps> = ({
 type ImageModalProps = {
   src: string
   alt: string
+  className?: string
   onClose: () => void
 }
 

--- a/packages/orion/src/ZoomImage/index.tsx
+++ b/packages/orion/src/ZoomImage/index.tsx
@@ -23,7 +23,13 @@ const ZoomImage: FunctionComponent<ZoomImageProps> = ({
         />
       )}
       <img src={src} alt={alt} />
-      <Button subtle secondary icon="zoom_in" onClick={() => setZoom(true)} />
+      <Button
+        subtle
+        secondary
+        icon="zoom_in"
+        onClick={() => setZoom(true)}
+        type="button"
+      />
     </div>
   )
 }

--- a/packages/orion/src/ZoomImage/index.tsx
+++ b/packages/orion/src/ZoomImage/index.tsx
@@ -7,14 +7,20 @@ import ImageModal from './ImageModal'
 const ZoomImage: FunctionComponent<ZoomImageProps> = ({
   src,
   alt,
-  className
+  className,
+  modalClassName
 }) => {
   const [zoom, setZoom] = useState(false)
 
   return (
     <div className={cx('orion-zoom-image', className, { zoom })}>
       {zoom && (
-        <ImageModal src={src} alt={alt} onClose={() => setZoom(false)} />
+        <ImageModal
+          className={modalClassName}
+          src={src}
+          alt={alt}
+          onClose={() => setZoom(false)}
+        />
       )}
       <img src={src} alt={alt} />
       <Button subtle secondary icon="zoom_in" onClick={() => setZoom(true)} />
@@ -26,6 +32,7 @@ type ZoomImageProps = {
   src: string
   alt: string
   className?: string
+  modalClassName?: string
 }
 
 export default ZoomImage


### PR DESCRIPTION
Como o Modal é renderizado fora do componente principal (um Portal), então estou adicionando a possibilidade de adicionar uma className nele tbm para podermos controlá-lo também