### PR TITLE
feature(TagsInput): Allow TagsInput to be controlled

### DIFF
--- a/packages/orion/src/TagsInput/TagsInput.stories.js
+++ b/packages/orion/src/TagsInput/TagsInput.stories.js
@@ -56,3 +56,18 @@ export const insideForm = () => {
     </Form>
   )
 }
+
+export const Controlled = () => {
+  const [value, setValue] = React.useState(['tag1', 'tag2'])
+
+  return (
+    <TagsInput
+      placeholder={text('Placeholder', 'Type here')}
+      error={boolean('error', false)}
+      fluid={boolean('fluid', false)}
+      selectOnBlur={boolean('selectOnBlur', true)}
+      value={value}
+      onChange={(_, { value }) => setValue(value)}
+    />
+  )
+}

--- a/packages/orion/src/TagsInput/TagsInput.test.js
+++ b/packages/orion/src/TagsInput/TagsInput.test.js
@@ -11,46 +11,53 @@ it('should render initial values when defaultValue is given', () => {
   MOCK_VALUES.forEach(value => expect(queryByText(value)).toBeTruthy())
 })
 
-it('should trigger the onChange callback when the value is changed', () => {
-  const mockOnChange = jest.fn()
-  const { getByRole, getByText } = render(
-    <TagsInput
-      onChange={mockOnChange}
-      placeholder="placeholder"
-      addValueKeys={[
-        TagsInput.KeyboardKeys.ENTER,
-        TagsInput.KeyboardKeys.TAB,
-        TagsInput.KeyboardKeys.COMMA
-      ]}
-    />
-  )
+it('should render initial values when value is given', () => {
+  const { queryByText } = render(<TagsInput value={MOCK_VALUES} />)
+  MOCK_VALUES.forEach(value => expect(queryByText(value)).toBeTruthy())
+})
 
-  const input = getByRole('combobox').childNodes[0]
+describe('when selectOnBlur is not passed', () => {
+  it('should trigger the onChange without the search value', () => {
+    const mockOnChange = jest.fn()
+    const { getByRole, getByText } = render(
+      <TagsInput
+        onChange={mockOnChange}
+        placeholder="placeholder"
+        addValueKeys={[
+          TagsInput.KeyboardKeys.ENTER,
+          TagsInput.KeyboardKeys.TAB,
+          TagsInput.KeyboardKeys.COMMA
+        ]}
+      />
+    )
 
-  // adds 'Black'
-  fireEvent.change(input, { target: { value: 'Black' } })
-  fireEvent.keyDown(input, { keyCode: keyboardKey.Enter })
+    const input = getByRole('combobox').childNodes[0]
 
-  // adds 'White'
-  fireEvent.change(input, { target: { value: 'White' } })
-  fireEvent.keyDown(input, { keyCode: keyboardKey.Tab })
+    // adds 'Black'
+    fireEvent.change(input, { target: { value: 'Black' } })
+    fireEvent.keyDown(input, { keyCode: keyboardKey.Enter })
 
-  // adds 'Gray'
-  fireEvent.change(input, { target: { value: 'Gray' } })
-  fireEvent.keyDown(input, { keyCode: keyboardKey.Comma })
+    // adds 'White'
+    fireEvent.change(input, { target: { value: 'White' } })
+    fireEvent.keyDown(input, { keyCode: keyboardKey.Tab })
 
-  // types 'Red' and do not press enter
-  fireEvent.change(input, { target: { value: 'Red' } })
+    // adds 'Gray'
+    fireEvent.change(input, { target: { value: 'Gray' } })
+    fireEvent.keyDown(input, { keyCode: keyboardKey.Comma })
 
-  expect(mockOnChange).toHaveBeenCalledWith(expect.anything(), {
-    value: ['Black', 'White', 'Gray', 'Red']
-  })
+    // types 'Red' and do not press enter
+    fireEvent.change(input, { target: { value: 'Red' } })
 
-  // removes 'Gray' by clicking in the remove icon in tag
-  fireEvent.click(getByText('Gray').children[0])
+    expect(mockOnChange).toHaveBeenCalledWith(expect.anything(), {
+      value: ['Black', 'White', 'Gray']
+    })
 
-  expect(mockOnChange).toHaveBeenLastCalledWith(expect.anything(), {
-    value: ['Black', 'White', 'Red']
+    // removes 'Gray' by clicking in the remove icon in tag
+    fireEvent.click(getByText('Gray').children[0])
+
+    expect(mockOnChange).toHaveBeenLastCalledWith(expect.anything(), {
+      value: ['Black', 'White']
+    })
   })
 })
 

--- a/packages/orion/src/TagsInput/index.js
+++ b/packages/orion/src/TagsInput/index.js
@@ -20,6 +20,7 @@ const AddValueKeyCodes = {
 const TagsInput = ({
   className,
   defaultValue,
+  value,
   onChange,
   onBlur,
   onSearchChange,
@@ -27,21 +28,21 @@ const TagsInput = ({
   addValueKeys,
   ...otherProps
 }) => {
-  const [values, setValues] = useState(defaultValue || [])
+  const [stateValues, setStateValues] = useState(value || defaultValue || [])
   const [search, setSearch] = useState('')
-  const [options, setOptions] = useState(
-    _.map(defaultValue, value => ({ value, text: value }))
-  )
+
+  const values = _.isUndefined(value) ? stateValues : value
+
+  const options = _.map(values, value => ({ value, text: value }))
   const addValuesKeyboardKeys = _.map(
     addValueKeys,
     key => AddValueKeyCodes[key]
   )
 
   const handleAddTagValue = func => {
-    setValues(values => {
+    setStateValues(values => {
       const changed = func(values)
 
-      setOptions(_.map(changed, value => ({ value, text: value })))
       onChange && onChange({}, { value: changed })
       return changed
     })
@@ -68,10 +69,9 @@ const TagsInput = ({
       searchQuery={search}
       onChange={(e, { value: newValue }) => {
         // This will be used to delete tag values
-        setOptions(_.map(newValue, value => ({ value, text: value })))
-        setValues(newValue)
+        setStateValues(newValue)
 
-        onChange && onChange({}, { value: _.concat(newValue, search || []) })
+        onChange && onChange(e, { value: newValue })
       }}
       onSearchChange={(event, data) => {
         const { searchQuery } = data
@@ -83,8 +83,6 @@ const TagsInput = ({
           setSearch('')
         } else if (_.trim(searchQuery) !== ',') {
           setSearch(searchQuery)
-          onChange &&
-            onChange(event, { value: _.concat(values, searchQuery || []) })
         }
 
         onSearchChange && onSearchChange(event, data)
@@ -119,6 +117,7 @@ const shouldPreventDefault = (keyCode, addValueKeys) =>
 TagsInput.propTypes = {
   className: PropTypes.string,
   defaultValue: PropTypes.array,
+  value: PropTypes.array,
   onChange: PropTypes.func,
   onSearchChange: PropTypes.func,
   onBlur: PropTypes.func,
@@ -127,7 +126,8 @@ TagsInput.propTypes = {
 }
 
 TagsInput.defaultProps = {
-  addValueKeys: ['comma']
+  addValueKeys: [KeyboardKeys.COMMA],
+  selectOnBlur: true
 }
 
 TagsInput.KeyboardKeys = KeyboardKeys


### PR DESCRIPTION
O que foi feito:

1. onChange: Só é disparado se uma tag for adicionada ou removida, com os valores das tags, e não do search.
2. Se o selectOnBlur estiver ativado, o search vai ser transformado em tag, o que entraria como valor no 1.
3. Por default, selectOnBlur vem `true`, isto faz com que não quebre quem já estava usando o `TagsInput`.
3. Adicionaria o value, que reseta as tags, fazendo o componente ficar controlado.

Tentei adicionar um teste pra quando o `selectOnBlur` estiver ativado, mas não consegui  fazer o evento de Blur ser disparado no React Testing Library.

Na animação abaixo, eu apenas tiro o foco do elemento, para o search ser transformado:
![2020-06-04 12 48 41](https://user-images.githubusercontent.com/1139664/83779016-c972bd80-a661-11ea-9f7c-5f87d7e868e7.gif)

OBS: Antes, eu alinhei este comportamento com @llaryssa e @brunoperruci-inloco .