### PR TITLE
fix(tags-input): Fix behavior when controlled

### DIFF
--- a/packages/orion/src/TagsInput/TagsInput.stories.js
+++ b/packages/orion/src/TagsInput/TagsInput.stories.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { text, withKnobs, boolean } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 
-import { Form, TagsInput } from '..'
+import { Form, Button, TagsInput } from '..'
 import { Sizes } from '../utils/sizes'
 
 export default {
@@ -61,13 +61,16 @@ export const Controlled = () => {
   const [value, setValue] = React.useState(['tag1', 'tag2'])
 
   return (
-    <TagsInput
-      placeholder={text('Placeholder', 'Type here')}
-      error={boolean('error', false)}
-      fluid={boolean('fluid', false)}
-      selectOnBlur={boolean('selectOnBlur', true)}
-      value={value}
-      onChange={(_, { value }) => setValue(value)}
-    />
+    <div className="flex items-center space-x-8">
+      <TagsInput
+        placeholder={text('Placeholder', 'Type here')}
+        error={boolean('error', false)}
+        fluid={boolean('fluid', false)}
+        selectOnBlur={boolean('selectOnBlur', true)}
+        value={value || []}
+        onChange={(_, { value }) => setValue(value)}
+      />
+      <Button onClick={() => setValue(null)}>Clear All</Button>
+    </div>
   )
 }

--- a/packages/orion/src/TagsInput/index.js
+++ b/packages/orion/src/TagsInput/index.js
@@ -39,17 +39,13 @@ const TagsInput = ({
     key => AddValueKeyCodes[key]
   )
 
-  const handleAddTagValue = func => {
-    setStateValues(values => {
-      const changed = func(values)
-
-      onChange && onChange({}, { value: changed })
-      return changed
-    })
+  const handleAddTagValue = values => {
+    setStateValues(values)
+    onChange && onChange({}, { value: values })
   }
 
   const addCurrentValue = () => {
-    handleAddTagValue(values => _.concat(values, search))
+    handleAddTagValue(_.concat(values, search))
     setSearch('')
   }
 
@@ -79,7 +75,7 @@ const TagsInput = ({
         const commaSplit = _.compact(_.map(_.split(searchQuery, ','), _.trim))
 
         if (_.size(commaSplit) > 1) {
-          handleAddTagValue(values => _.concat(values, commaSplit))
+          handleAddTagValue(_.concat(values, commaSplit))
           setSearch('')
         } else if (_.trim(searchQuery) !== ',') {
           setSearch(searchQuery)


### PR DESCRIPTION
Pô, notei um bug quando ele estava controlado, e o `value` era modificado do lado de fora do componente:

Antes:
![2020-06-04 15 18 28](https://user-images.githubusercontent.com/1139664/83796083-d0f09180-a676-11ea-8ebc-482e5f2620dd.gif)

Depois:
![2020-06-04 15 19 24](https://user-images.githubusercontent.com/1139664/83796093-d5b54580-a676-11ea-8e0c-b1a4f5fe7376.gif)


O que acontece é que o setState estava considerando o state interior do componente pra setar o novo state.

A correção foi ele usar o `values`, que é o valor correto.
