### PR TITLE
feature(multi-select-filter): Allow children to be passed

### DIFF
--- a/packages/orion/src/MultiSelectFilter/MultiSelectFilter.stories.js
+++ b/packages/orion/src/MultiSelectFilter/MultiSelectFilter.stories.js
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { object, text, withKnobs } from '@storybook/addon-knobs'
 
 import MultiSelectFilter from './'
+import { Menu } from '..'
 
 const actions = {
   onApply: action('onApply'),
@@ -27,5 +28,37 @@ export const basic = () => {
       options={options}
       {...actions}
     />
+  )
+}
+
+export const withChildren = () => {
+  const options = object('Options', [
+    { text: 'Strawberry', description: 'Red', value: 1 },
+    { text: 'Banana', description: 'Yellow', value: 2 },
+    { text: 'Watermelon', description: 'Green', value: 3 }
+  ])
+  const switcherOptions = [
+    {
+      name: 'Show Only',
+      key: 'show-only'
+    },
+    {
+      name: 'Show All Except',
+      key: 'except'
+    }
+  ]
+  return (
+    <MultiSelectFilter
+      text={text('text', 'Fruits')}
+      placeholder={text('Placeholder', 'Pick your fruits')}
+      options={options}
+      {...actions}>
+      <Menu
+        className="mb-8"
+        switcher
+        items={switcherOptions}
+        defaultActiveIndex={0}
+      />
+    </MultiSelectFilter>
   )
 }

--- a/packages/orion/src/MultiSelectFilter/index.js
+++ b/packages/orion/src/MultiSelectFilter/index.js
@@ -9,6 +9,7 @@ import { buildSelectedTextFromArray } from '../utils/filters'
 const MultiSelectFilter = ({
   bar,
   className,
+  children,
   dropdownProps,
   onApply,
   options,
@@ -45,20 +46,23 @@ const MultiSelectFilter = ({
       })}
       {...otherProps}>
       {({ onChange, value }) => (
-        <Dropdown
-          fluid
-          selection
-          multiple="keep"
-          search
-          inlineMenu
-          icon="search"
-          options={_.map(options, option => _.omit(option, 'tooltipText'))}
-          placeholder={placeholder}
-          searchInput={{ autoFocus: true }}
-          {...dropdownProps}
-          onChange={(_, { value }) => onChange(toNullIfEmpty(value))}
-          value={value || []}
-        />
+        <>
+          {children}
+          <Dropdown
+            fluid
+            selection
+            multiple="keep"
+            search
+            inlineMenu
+            icon="search"
+            options={_.map(options, option => _.omit(option, 'tooltipText'))}
+            placeholder={placeholder}
+            searchInput={{ autoFocus: true }}
+            {...dropdownProps}
+            onChange={(_, { value }) => onChange(toNullIfEmpty(value))}
+            value={value || []}
+          />
+        </>
       )}
     </ElementType>
   )
@@ -67,6 +71,7 @@ const MultiSelectFilter = ({
 MultiSelectFilter.propTypes = {
   bar: PropTypes.bool,
   className: PropTypes.string,
+  children: PropTypes.node,
   dropdownProps: PropTypes.object,
   onApply: PropTypes.func,
   options: PropTypes.array,


### PR DESCRIPTION
Permite que o `<MultiSelectFilter />` aceite uma prop `children`:

![image](https://user-images.githubusercontent.com/1139664/84062465-b891b700-a995-11ea-9e64-19649d6e0c49.png)

OBS: Os botões `Show Only` e `Show All Except` são o coteúdo do `children`.
