### PR TITLE
feat(Table): add Table.Footer

### DIFF
--- a/packages/orion/src/Table/Table.stories.js
+++ b/packages/orion/src/Table/Table.stories.js
@@ -43,6 +43,13 @@ export const basic = () => {
           </Table.Row>
         ))}
       </Table.Body>
+      <Table.Footer>
+        <Table.Row>
+          <Table.Cell colSpan="2" className="text-center">
+            Footer
+          </Table.Cell>
+        </Table.Row>
+      </Table.Footer>
     </Table>
   )
 }

--- a/packages/orion/src/Table/index.js
+++ b/packages/orion/src/Table/index.js
@@ -1,15 +1,16 @@
 import { Table as SemanticTable } from '@inloco/semantic-ui-react'
 import React from 'react'
 
-import TabelCell from './TableCell'
+import TableCell from './TableCell'
 import TableHeaderCell from './TableHeaderCell'
 
 const Table = props => <SemanticTable {...props} />
 
 Table.Body = SemanticTable.Body
-Table.Cell = TabelCell
+Table.Cell = TableCell
 Table.Header = SemanticTable.Header
 Table.HeaderCell = TableHeaderCell
 Table.Row = SemanticTable.Row
+Table.Footer = SemanticTable.Footer
 
 export default Table

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -49,12 +49,14 @@
 
 .orion.table tbody > tr > td:first-child > .inner-cell {
   @apply border-l-1 pl-24;
-  border-radius: 4px 0 0 4px;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
 }
 
 .orion.table tbody > tr > td:last-child > .inner-cell {
   @apply border-r-1 pr-16;
-  border-radius: 0 4px 4px 0;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .orion.table tbody > tr > td > .inner-cell {
@@ -70,6 +72,28 @@
 
 .orion.table tbody .inner-cell.highlight > .inner-cell-wrapper {
   @apply bg-gray-900-4;
+}
+
+/** Footer **/
+
+.orion.table tfoot > tr > td {
+  @apply p-0;
+}
+
+.orion.table tfoot > tr > td > .inner-cell {
+  @apply bg-gray-900-8 mt-8 p-8;
+}
+
+.orion.table tfoot > tr > td:first-child > .inner-cell {
+  @apply pl-24;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.orion.table tfoot > tr > td:last-child > .inner-cell {
+  @apply pr-16;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 /** Sortable **/


### PR DESCRIPTION
Adicionando o componente `Table.Footer` que ainda não estava incluído. Segui o estilo do protótipo da página de credenciais:
![Screen Shot 2020-06-11 at 12 39 26](https://user-images.githubusercontent.com/9112403/84406962-99d33080-abe0-11ea-9fd5-d90e2b755fed.png)



Storybook:
![Screen Shot 2020-06-11 at 12 38 10](https://user-images.githubusercontent.com/9112403/84406916-8b851480-abe0-11ea-9cce-333799083f11.png)
