### PR TITLE
fix(NotificationCenter): remove margin-left for positioning

### DIFF
--- a/packages/orion/src/NotificationCenter/notificationCenter.css
+++ b/packages/orion/src/NotificationCenter/notificationCenter.css
@@ -4,10 +4,6 @@
   width: 600px;
 }
 
-.orion-notification-center.Toastify__toast-container--top-center {
-  margin-left: -300px;
-}
-
 .orion-notification-center__toast.Toastify__toast {
   @apply shadow-none p-0 m-0 mb-8 min-h-0 font-default overflow-visible;
   color: inherit;


### PR DESCRIPTION
Na versão 6.0.0 do `react-toastify` está sendo usado o  `transform` pra mover o toast pro centro, ao invés do `margin-left` negativo ([Release notes](https://github.com/fkhadra/react-toastify/releases/tag/v6.0.0))
![Screen Shot 2020-06-11 at 17 06 57](https://user-images.githubusercontent.com/9112403/84434440-6d320f80-ac06-11ea-9eb5-67f143d3ed9b.png)

Mas aqui ainda estávamos "sobreescrevendo" o [agora inexistente inexistente] margin-left, fazendo o toast ter dois deslocamentos para a esquerda e deixar de estar centralizado.
![orion-toastify-position](https://user-images.githubusercontent.com/9112403/84434470-78853b00-ac06-11ea-9dfe-d32c0c2f08fd.gif)

Estou removendo a regra pra ficar okay
![orion-toastify-position-fix](https://user-images.githubusercontent.com/9112403/84434493-7fac4900-ac06-11ea-845a-4ce77bb54513.gif)
