### PR TITLE
feature(filter): Allow FilterBar to have another children types

### DIFF
--- a/packages/orion/src/FilterBar/FilterBar.stories.js
+++ b/packages/orion/src/FilterBar/FilterBar.stories.js
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { withKnobs } from '@storybook/addon-knobs'
 import PropTypes from 'prop-types'
 
-import { FilterBar, Input } from '../'
+import { FilterBar, Input, Icon } from '../'
 
 const actions = {
   onChange: action('onChange')
@@ -22,6 +22,20 @@ export const basic = () => (
     <FilterBar.Filter text="Filter 2" name="filter2">
       {filterProps => <FilterStoryInput {...filterProps} />}
     </FilterBar.Filter>
+    <FilterBar.Filter text="Filter 3" name="filter3">
+      {filterProps => <FilterStoryInput {...filterProps} />}
+    </FilterBar.Filter>
+  </FilterBar>
+)
+
+export const differentFilterBarChildren = () => (
+  <FilterBar {...actions} className="flex items-center">
+    <Icon name="filter_list" className="mr-16" />
+    {true && (
+      <FilterBar.Filter text="Filter 1" name="filter1">
+        {filterProps => <FilterStoryInput {...filterProps} />}
+      </FilterBar.Filter>
+    )}
     <FilterBar.Filter text="Filter 3" name="filter3">
       {filterProps => <FilterStoryInput {...filterProps} />}
     </FilterBar.Filter>

--- a/packages/orion/src/FilterBar/index.js
+++ b/packages/orion/src/FilterBar/index.js
@@ -23,11 +23,16 @@ const FilterBar = ({
   const [localValue, setLocalValue] = useState(value)
 
   const pendingFilters = {}
+
+  const isFilterType = child => child?.type === FilterBarFilter
+
   React.Children.forEach(children, child => {
-    const name = child.props.name
-    const local = _.get(localValue, name, null)
-    const final = _.get(value, name, null)
-    pendingFilters[name] = !_.isEqual(local, final)
+    if (isFilterType(child)) {
+      const name = child.props.name
+      const local = _.get(localValue, name, null)
+      const final = _.get(value, name, null)
+      pendingFilters[name] = !_.isEqual(local, final)
+    }
   })
   const hasPendingFilters = _.some(pendingFilters)
 
@@ -50,12 +55,15 @@ const FilterBar = ({
   return (
     <div className={cx(className, 'orion filter-bar')} {...otherProps}>
       {React.Children.map(children, child => {
-        const { name } = child.props
-        return React.cloneElement(child, {
-          onApply: handleFilterChange(name),
-          pending: pendingFilters[name],
-          value: _.get(localValue, name) || null
-        })
+        if (isFilterType(child)) {
+          const { name } = child.props
+          return React.cloneElement(child, {
+            onApply: handleFilterChange(name),
+            pending: pendingFilters[name],
+            value: _.get(localValue, name) || null
+          })
+        }
+        return child
       })}
       {hasPendingFilters &&
         Button.create(applyButton, {


### PR DESCRIPTION
O componente `<FilterBar />` só aceitava ter filhos que tivessem a prop name, porque só foi usado com o `<FilterBar.Filter />`.

Mas tem alguns casos que a gente precisa exibir um filtro dentro do FilterBar condicionalmente, ou precisamos adicionar um ícone, e aí o `<FilterBar />` quebrava.

Com esta alteração, é permitido passar qualquer tipo de filho pro `<FilterBar />`.
