### PR TITLE
Feature/filter handle apply

### DIFF
--- a/packages/orion/src/Filter/Filter.stories.js
+++ b/packages/orion/src/Filter/Filter.stories.js
@@ -4,7 +4,7 @@ import { object, text, withKnobs } from '@storybook/addon-knobs'
 import PropTypes from 'prop-types'
 import _ from 'lodash'
 
-import { Dropdown, Filter, Input } from '../'
+import { Button, Dropdown, Filter, Input } from '../'
 
 const actions = {
   onChange: action('onChange'),
@@ -102,6 +102,26 @@ const ControlledFilter = () => {
   )
 }
 export const withTrigger = () => <ControlledFilter />
+
+export const customApply = () => {
+  const value = text('Value to apply', 'value')
+  return (
+    <Filter
+      text={text('Label', 'Filter')}
+      applyButton={null}
+      clearButton={null}
+      {...actions}>
+      {({ handleApply }) => (
+        <Button
+          content="Click me to apply"
+          onClick={event => {
+            handleApply(event, value)
+          }}
+        />
+      )}
+    </Filter>
+  )
+}
 
 const FilterStoryInput = ({ onChange, value, ...otherProps }) => (
   <Input

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -40,9 +40,10 @@ const Filter = ({
 
   const isSelected = !_.isEmpty(value)
 
-  const handleApply = event => {
-    setValue(localValue)
-    onApply && onApply(localValue)
+  const handleApply = (event, value) => {
+    const newValue = value || localValue
+    setValue(newValue)
+    onApply && onApply(newValue)
 
     setOpen(false)
     onClose && onClose()
@@ -123,7 +124,7 @@ const Filter = ({
         onKeyDown={handleKeyDown}
         onSubmit={handleApply}>
         <div className="filter-content">
-          {children({ onChange: handleChange, value: localValue })}
+          {children({ onChange: handleChange, value: localValue, handleApply })}
         </div>
         <div className="filter-buttons">
           <div className={cx({ invisible: _.isEmpty(localValue) })}>

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -126,31 +126,35 @@ const Filter = ({
         <div className="filter-content">
           {children({ onChange: handleChange, value: localValue, handleApply })}
         </div>
-        <div className="filter-buttons">
-          <div className={cx({ invisible: _.isEmpty(localValue) })}>
-            {Button.create(clearButton, {
-              autoGenerateKey: false,
-              defaultProps: {
-                subtle: true,
-                type: 'button',
-                onClick: handleClear
-              }
-            })}
+        {(clearButton || applyButton || extraFooterContent) && (
+          <div className="filter-buttons">
+            <div className={cx({ invisible: _.isEmpty(localValue) })}>
+              {Button.create(clearButton, {
+                autoGenerateKey: false,
+                defaultProps: {
+                  subtle: true,
+                  type: 'button',
+                  onClick: handleClear
+                }
+              })}
+            </div>
+            <div className="flex items-baseline">
+              {extraFooterContent && (
+                <div className="filter-footer-content">
+                  {extraFooterContent}
+                </div>
+              )}
+              {Button.create(applyButton, {
+                autoGenerateKey: false,
+                defaultProps: {
+                  primary: true,
+                  subtle: true,
+                  type: 'submit'
+                }
+              })}
+            </div>
           </div>
-          <div className="flex items-baseline">
-            {extraFooterContent && (
-              <div className="filter-footer-content">{extraFooterContent}</div>
-            )}
-            {Button.create(applyButton, {
-              autoGenerateKey: false,
-              defaultProps: {
-                primary: true,
-                subtle: true,
-                type: 'submit'
-              }
-            })}
-          </div>
-        </div>
+        )}
       </ClickOutside>
     </Popup>
   )


### PR DESCRIPTION
Na pagina de metricas, vamos precisar de um filtro assim:
![Screen Shot 2020-06-23 at 15 46 06](https://user-images.githubusercontent.com/9112403/85444433-b2403500-b568-11ea-9486-c216ff5e1333.png)

Ele não utiliza o botão "apply" nem "clear", e aplica o valor ao clicar no Radio. Isso pede por um "apply" customizável, então estou repassando o `handleApply` como render prop para os children do Filter. Pra isso, estou fazendo a função aceitar um valor que vai ter prioridade sobre o `localValue` se usado.

Além disso, estou evitando renderizar o footer (que ocupa um espaço na parte inferior do menu) caso os botões não sejam utilizados. Novo story:

![orion-custom-apply](https://user-images.githubusercontent.com/9112403/85444686-fc291b00-b568-11ea-8a59-5006805dc44a.gif)


