### PR TITLE
feat(tailwing.config.js): adds 18px lineHeight config

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -270,7 +270,8 @@ module.exports = {
       '20': '20px',
       '24': '24px',
       // TODO: refactor line heights to use 14/20, 12/18, 18/24
-      '18': '18px'
+      '18': '18px',
+      '26': '26px'
     },
     listStyleType: {
       none: 'none',

--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -268,7 +268,9 @@ module.exports = {
       // 12/14, 14/20, 20/24, 24/28
       '14': '14px',
       '20': '20px',
-      '24': '24px'
+      '24': '24px',
+      // TODO: refactor line heights to use 14/20, 12/18, 18/24
+      '18': '18px'
     },
     listStyleType: {
       none: 'none',


### PR DESCRIPTION
há um tempo, bruno vem mandando protótipos que tem lugares onde o line-height tá diferente do que a gente adota (e do que tem no orion). conversei com ele e isso resultou nesse card https://www.notion.so/inlocoglobal/Line-height-da-fonte-12px-t-14px-ao-inv-s-de-18px-b14d69660e104e5fa54e5338feeed226. comecei a resolver o card há um tempo atrás mas ele é muito arriscado, pq mexe em muitaaaa coisa. acredito que essa mudança tenha que fazer passo a passo com um designer.
como ainda não vamos mudar tudo, adicionei esse line height de 18px ao orion pra ir colocando em alguns textos do frontend. o que acham?