### PR TITLE
Feature/update user profile

### DIFF
--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -66,7 +66,6 @@ export const basic = () => (
         )}
         {boolean('Enabled', true, 'UserProfile.HeaderItem') && (
           <Layout.UserProfile.HeaderItem
-            selected={boolean('Selected', true, 'UserProfile.HeaderItem')}
             title={text('Title', 'In Loco', 'UserProfile.HeaderItem')}
             label={text('Label', 'admin', 'UserProfile.HeaderItem')}>
             <Layout.UserProfile.Icon>

--- a/packages/orion/src/Layout/LayoutUserProfile/UserProfileHeaderItem/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/UserProfileHeaderItem/index.js
@@ -10,7 +10,6 @@ const UserProfileHeaderItem = ({
   children,
   title,
   label,
-  selected,
   ...otherProps
 }) => {
   const [iconChildren, otherChildren] = _.partition(
@@ -19,11 +18,7 @@ const UserProfileHeaderItem = ({
   )
 
   return (
-    <div
-      className={cx('header-item', {
-        selected
-      })}
-      {...otherProps}>
+    <div className="header-item" {...otherProps}>
       <div className="header-item-content">
         {iconChildren}
         <div className="header-item-title">{title}</div>
@@ -38,8 +33,7 @@ UserProfileHeaderItem.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
   title: PropTypes.string.isRequired,
-  label: PropTypes.string,
-  selected: PropTypes.bool
+  label: PropTypes.string
 }
 
 export default UserProfileHeaderItem

--- a/packages/orion/src/Layout/LayoutUserProfile/UserProfileHeaderItem/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/UserProfileHeaderItem/index.js
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -98,11 +98,6 @@
   width: 320px !important;
 }
 
-.orion.layout .layout-user-profile-children-container {
-  @apply overflow-y-auto;
-  max-height: 433px; /* Six times 72px plus 1px divider */
-}
-
 /**
  * Dropdown Header
  */

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -129,21 +129,11 @@
   @apply flex items-center cursor-auto relative  p-16;
 }
 
-.orion.layout .layout-user-profile .header-item.selected {
-  @apply pl-32;
-}
-
-.orion.layout .layout-user-profile .header-item.selected:before {
-  @apply absolute w-8 h-8 rounded-full bg-wave-500;
-  content: ' ';
-  left: 16px;
-}
-
 /**
  * Dropdown Items 
  */
 .orion.layout .layout-user-profile .item {
-  @apply flex bg-gray-100 relative flex ml-0 py-16 pr-16 pl-32;
+  @apply flex bg-gray-100 relative flex ml-0 p-16;
 }
 
 .orion.layout .layout-user-profile .item:hover {

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -73,9 +73,8 @@
  * Edit Link
  */
 .orion.layout .user-profile-edit-link {
-  @apply flex text-sm items-center m-auto text-wave-600;
+  @apply inline-flex text-sm items-center m-auto text-wave-600;
   margin-top: 6px;
-  width: fit-content;
 }
 
 .orion.layout .user-profile-edit-link:hover {
@@ -102,7 +101,7 @@
  * Dropdown Header
  */
 .orion.layout .layout-user-profile .header {
-  @apply cursor-auto pt-16;
+  @apply flex flex-col cursor-auto pt-16;
 }
 
 .orion.layout .layout-user-profile .layout-user-profile-header-name {


### PR DESCRIPTION
Três coisinhas neste PR, por causa das últimas revisões da navegação.

1. Estou removendo a bolinha azul do User Profile. Ela pode ser removida apenas com a prop `selected`. Mas os outros itens não selecionados tbm têm uma margi-left para ficar de acordo, independente da prop (que fica em outro item). Então estou removendo tanto as props quanto os espaçamentos por causa dessa prop.

2. Fui testar os botões dentro dos itens não selecionados, e eles funcionam sem problemas. Mas a tooltip fica zoado:
![Screen Shot 2020-07-13 at 18 26 59](https://user-images.githubusercontent.com/9112403/87355860-7846cb00-c537-11ea-97cb-af7713b635c9.png)

Isso acontece pq o container tem um overflow-y: auto. Esse overflow existe para causar um scroll em casos de uma lista com muitas orgs. Mas para o tooltip ficar posicionado corretamente, teríamos que trocar para overflow: visible.

Como vimos que a grande maioria dos usuários só têm uma organização, achei que estava tudo bem tirar esse scroll em prol do tooltipo, o que vocês acham?
![Screen Shot 2020-07-13 at 18 31 10](https://user-images.githubusercontent.com/9112403/87356185-0458f280-c538-11ea-9d15-31e073a32ca7.png)



3. O `width: fit-content` é experimental e não funciona em todos os browsers. Temos alguns lugares para remover aqui na Orion, aqui é um deles. Então aproveitei o PR para fazê-lo.