### PR TITLE
feat(LayoutUserProfile): add tooltipOpen prop

### DIFF
--- a/packages/orion/src/Layout/LayoutUserProfile/UserProfileButton/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/UserProfileButton/index.js
@@ -20,7 +20,8 @@ const UserProfileButton = ({ tooltip, tooltipOpen, ...props }) => {
 }
 
 UserProfileButton.propTypes = {
-  tooltip: PropTypes.string
+  tooltip: PropTypes.string,
+  tooltipOpen: PropTypes.bool
 }
 
 export default UserProfileButton

--- a/packages/orion/src/Layout/LayoutUserProfile/UserProfileButton/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/UserProfileButton/index.js
@@ -1,13 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import _ from 'lodash'
 
 import Button from '../../../Button'
 import Tooltip from '../../../Tooltip'
 
-const UserProfileButton = ({ tooltip, ...props }) => {
+const UserProfileButton = ({ tooltip, tooltipOpen, ...props }) => {
   const button = <Button secondary subtle icon {...props} />
   return tooltip ? (
-    <Tooltip trigger={button} position="top center" content={tooltip} />
+    <Tooltip
+      {...(!_.isUndefined(tooltipOpen) && { open: tooltipOpen })}
+      trigger={button}
+      position="top center"
+      content={tooltip}
+    />
   ) : (
     button
   )


### PR DESCRIPTION
Nas novas mudanças da navegação, foi incluído os botões de home e settings dentro das orgs não selecionadas.
![Screen Shot 2020-07-14 at 12 43 42](https://user-images.githubusercontent.com/9112403/87446427-abd53400-c5cf-11ea-9b62-e7d1a99210f2.png)

Esses botões são links (`<a />`), mas o item da org tbm é clicável, e é um link também.
Não podemos implementar um link dentro de link pois vai contra as validações da DOM
> Warning: validateDOMNesting(...): \<a> cannot appear as a descendant of \<a>

Consegui resolver isso transformando os itens e botões em `<a />` apenas quando necessário com um state, usando `onMouseEnter` e `onMouseLeave`.
```
<Layout.UserProfile.Item
  ...
  {...(!over && { as: 'a', href: '/item' })}>
  ...
  <Layout.UserProfile.Button
    tooltip="Tooltip"
    {...(over && {
      as: 'a',
      href: '/button'
    })}
    onMouseEnter={() => setOver(true)}
    onMouseLeave={() => setOver(false)}>
    <Icon name="home" />
  </Layout.UserProfile.Button>
</Layout.UserProfile.Item>
```

Porém, por trocar a DOM no `.Item`, o tooltip do semantic acaba não reconhecendo o evento de entrada para exibir o tooltip:
![orion-tooltip-before](https://user-images.githubusercontent.com/9112403/87446957-5baaa180-c5d0-11ea-93b1-724dd89804d2.gif)

Então estou adicionando a prop `tooltipOpen` para que possamos, também usando esse state, controlar quando o tooltip aparece. Se eu mudar o código acima para 
```
<Layout.UserProfile.Button
    tooltip="Tooltip"
    {...(over && {
      as: 'a',
      href: '/button',
	  tooltipOpen: true
    })}
```
funciona:
![orion-tooltip-after](https://user-images.githubusercontent.com/9112403/87447084-84cb3200-c5d0-11ea-9b23-25632e8e73de.gif)
