### PR TITLE
Feature: normal font on active item in dropdown

### DIFF
--- a/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
+++ b/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
@@ -7,10 +7,6 @@
   @apply block px-16 py-8;
 }
 
-.orion.dropdown .menu > .item.active {
-  @apply font-medium;
-}
-
 .orion.dropdown .menu > .item:hover {
   @apply bg-gray-900-8;
 }


### PR DESCRIPTION
Victinho me chamou a atenção sobre esse dropdown, não era pra o item ficar em negrito ao ser selecionado:
![Screen Shot 2020-07-15 at 17 34 41](https://user-images.githubusercontent.com/15937541/87593326-ac4df780-c6c1-11ea-8a0b-66d16318f82d.png)

Victinho e Bruno aproveitaram e decidiram remover esse negrito de todos os outros dropdowns, incluindo o que não é multiple selection. A ideia é que o item selecionado já tem o background cinza destacado, então é reduntante.
![Screen Shot 2020-07-15 at 18 42 14](https://user-images.githubusercontent.com/15937541/87601167-ebcd1180-c6ca-11ea-9097-1fdd4ccd3442.png)
