### PR TITLE
Fix: truncate username and label (organization name)

### DIFF
--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -47,7 +47,7 @@ const LayoutUserProfile = ({
             )}
           </div>
           <div className="layout-user-profile-trigger-texts">
-            {name}
+            <div>{name}</div>
             {label && <label>{label}</label>}
           </div>
         </div>

--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -12,6 +12,11 @@
 
 .orion.layout .layout-user-profile-trigger-texts {
   @apply flex flex-col justify-center ml-8;
+  max-width: 108px;
+}
+
+.orion.layout .layout-user-profile-trigger-texts > * {
+  @apply truncate;
 }
 
 .orion.layout .layout-user-profile:hover {


### PR DESCRIPTION
**Antes**
![Screen Shot 2020-07-20 at 15 03 29](https://user-images.githubusercontent.com/15937541/87970495-37503880-ca9a-11ea-825d-8c7ff59e7bf0.png)

**Depois**
![Screen Shot 2020-07-20 at 15 01 33](https://user-images.githubusercontent.com/15937541/87970394-0cfe7b00-ca9a-11ea-84a6-8b515b7214c5.png)

O `max-width: 108px` foi pego do [Invision](https://inloco.invisionapp.com/d/main?origin=v7#/console/19947146/424694082/inspect?scrollOffset=1791). O dropdown todo tem que ser 192px, mas pro truncate funcionar, o limite tem que ficar no pai imediato.