### PR TITLE
feat(input.css): adds padding in the right

### DIFF
--- a/packages/orion/src/Input/input.css
+++ b/packages/orion/src/Input/input.css
@@ -3,7 +3,7 @@
   width: 256px;
 }
 .orion.input > input {
-  @apply h-full pl-16 flex justify-center outline-none w-full;
+  @apply h-full px-16 flex justify-center outline-none w-full;
   @apply bg-white border border-solid border-gray-900-24 rounded;
 }
 


### PR DESCRIPTION
antes:
![input-1](https://user-images.githubusercontent.com/4022430/88592010-ac3fe700-d033-11ea-9d6e-24cc03d18560.gif)

depois:
![input-2](https://user-images.githubusercontent.com/4022430/88592015-af3ad780-d033-11ea-8d4e-c38bc63f7595.gif)
