### PR TITLE
feature(Icon): add aria-label

### DIFF
--- a/packages/orion/src/Icon/index.js
+++ b/packages/orion/src/Icon/index.js
@@ -15,7 +15,12 @@ const Icon = ({ as: AsElementType, className, color, name, ...otherProps }) => {
     [`fill-${color}`]: isCustomIcon && color
   })
   return (
-    <ElementType className={classes} name={name} role="img" {...otherProps}>
+    <ElementType
+      className={classes}
+      name={name}
+      role="img"
+      aria-label={name}
+      {...otherProps}>
       {name}
     </ElementType>
   )


### PR DESCRIPTION
Mesmo adicionando o role e o name, o ícone ainda não estava acessível com `getByRole("img", { name: "xalala" })`. Adicionei o `aria-label` para corrigir isso.

<img width="356" alt="Screen Shot 2020-08-03 at 11 49 57 AM" src="https://user-images.githubusercontent.com/28961613/89195839-b9069280-d57f-11ea-90c8-5073b63f3f62.png">
<img width="260" alt="Screen Shot 2020-08-03 at 11 49 46 AM" src="https://user-images.githubusercontent.com/28961613/89195844-bad05600-d57f-11ea-8776-c266dbd21e3b.png">
