### PR TITLE
chore(atomic-bomb): set lighter wave shade for links

### DIFF
--- a/packages/atomic-bomb/css/base.css
+++ b/packages/atomic-bomb/css/base.css
@@ -15,15 +15,15 @@ h2 {
 }
 
 a {
-  @apply text-wave-600;
+  @apply text-wave-500;
 }
 
 a:hover {
-  @apply text-wave-700;
+  @apply text-wave-600;
 }
 
 a:active {
-  @apply text-wave-800;
+  @apply text-wave-700;
 }
 
 ::placeholder,


### PR DESCRIPTION
A cor implementada para os links estava um tom mais escuro em relação aos protótipos:
https://inloco.invisionapp.com/d/main?origin=v7#/console/17711749/367438614/inspect?scrollOffset=641
