### PR TITLE
fix(layoutUserProfile): change editLink to new link style

### DIFF
--- a/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
+++ b/packages/orion/src/Layout/LayoutUserProfile/layoutUserProfile.css
@@ -78,16 +78,20 @@
  * Edit Link
  */
 .orion.layout .user-profile-edit-link {
-  @apply inline-flex text-sm items-center m-auto text-wave-600;
+  @apply inline-flex text-sm items-center m-auto;
   margin-top: 6px;
 }
 
-.orion.layout .user-profile-edit-link:hover {
-  @apply text-wave-700;
+.orion.layout .user-profile-edit-link:not(a) {
+  @apply text-wave-500 font-medium;
 }
 
-.orion.layout .user-profile-edit-link:active {
-  @apply text-wave-800;
+.orion.layout .user-profile-edit-link:not(a):hover {
+  @apply text-wave-600;
+}
+
+.orion.layout .user-profile-edit-link:not(a):active {
+  @apply text-wave-700;
 }
 
 .orion.layout .user-profile-edit-link > .orion.icon {


### PR DESCRIPTION
O estilo dos links foi atualizado nas últimas mudanças do orion. Antes era regular wave-600, agora é medium wave-500.

A mudança já foi aplicada no css base daqui, mas neste link havia uma definição explícita das cores, o que estava sobreescrevendo a dos links e acabou não sofrendo mudança aqui.

Essa definição não é necessária para o caso default que esse `EditLink` é um `a`, mas estava sendo aplicado de qqr forma. Então, além de atualizar para o novo estilo, deixei aplicando apenas se o elemento for diferente de `a` (o que pode ser definido pela prop `as`).