### PR TITLE
fix(menu-item): Set correct font-weight

### DIFF
--- a/packages/orion/src/Menu/menu.css
+++ b/packages/orion/src/Menu/menu.css
@@ -5,16 +5,12 @@
 }
 
 .orion.menu .item {
-  @apply cursor-pointer flex items-center ml-24 outline-none text-base text-gray-800;
+  @apply cursor-pointer flex items-center ml-24 outline-none text-base font-normal text-gray-800;
 }
 
 .orion.menu .item:hover,
 .orion.menu .item:focus {
   @apply text-gray-700;
-}
-
-.orion.menu .item:active {
-  @apply text-gray-900;
 }
 
 .orion.menu .item:first-child {


### PR DESCRIPTION
Efeito colateral de ter setado `font-weight` no `<a>`, os itens de menu ficaram `bold`.

Este PR faz eles voltarem a ser `normal`.

![image](https://user-images.githubusercontent.com/1139664/91196954-29ad5480-e6d1-11ea-8fcb-a9b75743dba6.png)
