### PR TITLE
fix(dropdown-multiple): Set font-normal with dropdown multiple

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -100,7 +100,7 @@
 }
 
 .orion.dropdown.multiple .orion.label {
-  @apply mr-16 my-2;
+  @apply mr-16 my-2 font-normal;
   margin-left: -8px;
 }
 


### PR DESCRIPTION
Outro efeito colateral aqui...
No Dropdown multiple, o Semantic seta um `<Label />` as `a `.

https://github.com/Semantic-Org/Semantic-UI-React/blob/master/src/modules/Dropdown/Dropdown.js#L938

Antes:
![image](https://user-images.githubusercontent.com/1139664/91208339-72203e80-e6e0-11ea-9344-2ca4acae162b.png)

Depois:
![image](https://user-images.githubusercontent.com/1139664/91208309-659be600-e6e0-11ea-9aa9-574d2c5f3175.png)

