### PR TITLE
fix(dropdown): set font-normal to dropdown text

### DIFF
--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -23,7 +23,7 @@
 }
 
 .orion.dropdown .text {
-  @apply text-gray-900 truncate z-10;
+  @apply text-gray-900 font-normal truncate z-10;
 }
 
 .orion.dropdown > .text {


### PR DESCRIPTION
Mais um que tinha sido afetado pelo font-weight dos links.

No exemplo abaixo, coloquei `as='a'` no "Account":
Antes
![Screen Shot 2020-08-27 at 16 16 27](https://user-images.githubusercontent.com/9112403/91485285-fe696780-e880-11ea-9e65-7f43f29943b9.png)

Depois
![Screen Shot 2020-08-27 at 16 16 40](https://user-images.githubusercontent.com/9112403/91485289-01645800-e881-11ea-8a34-23d968c66ed4.png)
