### PR TITLE
fix(form-field): Set textarea border red when error

### DIFF
--- a/packages/orion/src/Form/Field/field.css
+++ b/packages/orion/src/Form/Field/field.css
@@ -79,6 +79,7 @@
 
 /* Error */
 .orion.form .field.error input,
+.orion.form .field.error textarea,
 .orion.form .field.error .dropdown {
   @apply border-magenta-500;
 }


### PR DESCRIPTION
Quando o textarea tava dentro de um `Field`, a borda não estava ficando vermelha em um erro.
