### PR TITLE
fix(layout): enforce apps dropdown item fontWeight and color

### DIFF
--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -96,7 +96,7 @@
  * Apps Dropdown Item
  */
 .orion.layout .layout-apps-dropdown > .menu > .item {
-  @apply flex items-center py-16 px-32;
+  @apply flex items-center py-16 px-32 font-normal text-gray-900;
 }
 
 .orion.layout .layout-apps-dropdown > .menu > .item:hover {


### PR DESCRIPTION
Último afetado aqui, segundo a [revisão de Bruno](https://www.notion.so/inlocoglobal/Fix-link-style-after-Orion-update-5a60530784e349dbb72b0bbe167d59f4)

Se usar um `a`:
Antes:
![Screen Shot 2020-08-28 at 17 53 38](https://user-images.githubusercontent.com/9112403/91614384-dd277a80-e957-11ea-82fa-85792ac65147.png)

Depois:
![Screen Shot 2020-08-28 at 17 54 49](https://user-images.githubusercontent.com/9112403/91614392-e0226b00-e957-11ea-9c58-994a9c94b3b6.png)
