### PR TITLE
chore(tailwind): set removeDeprecatedGapUtilities flag

### DIFF
--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -476,5 +476,8 @@ module.exports = {
     zIndex: ['responsive']
   },
   corePlugins: {},
-  plugins: []
+  plugins: [],
+  future: {
+    removeDeprecatedGapUtilities: true
+  }
 }


### PR DESCRIPTION
Na `v1.7` do tailwind, as classes `col-gap-x` e `row-gap-x` estão sendo depreciadas. Changelog: [link](https://github.com/tailwindlabs/tailwindcss/releases/tag/v1.7.0)

Com isso, surge um novo alerta na hora do build sugerindo a troca pelas regras novas equivalentes:
![Screen Shot 2020-08-28 at 18 26 57](https://user-images.githubusercontent.com/9112403/91616797-d6e7cd00-e95c-11ea-9879-318868d86c2b.png)

Já estou trocando no `inloco-frontend` neste PR: https://github.com/inloco/inloco-frontend/pull/1402
No `4apps-js` e no `inloco-accounts` não encontrei estas regras sendo utilizadas.

Então estou setando esta flag como recomendado na documentação do Tailwind. Isso ira remover o alerta e as regras depreciadas do build na próxima release.