### PR TITLE
feature(loading-icon): Adjust colors for inverted state

### DIFF
--- a/packages/orion/src/Icon/Icon.stories.js
+++ b/packages/orion/src/Icon/Icon.stories.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import cx from 'classnames'
 import { text, withKnobs } from '@storybook/addon-knobs'
 
 import { Card, Icon } from '../'
@@ -14,12 +15,17 @@ export const basic = () => (
 )
 
 export const customIcons = () => {
-  const IconCard = ({ name }) => (
-    <Card className="flex flex-col items-center m-8 ml-0 p-4 w-48">
-      <Icon name={name} />
-      <div className="text-sm">{name}</div>
-    </Card>
-  )
+  const IconCard = ({ name, inverted }) => {
+    const classNames = cx('flex flex-col items-center m-8 ml-0 p-4 w-48', {
+      'bg-gray-800': inverted
+    })
+    return (
+      <Card className={classNames}>
+        <Icon name={name} />
+        <div className="text-sm">{name}</div>
+      </Card>
+    )
+  }
   IconCard.propTypes = {
     name: PropTypes.string
   }
@@ -37,6 +43,7 @@ export const customIcons = () => {
         <IconCard name="ios" />
         <IconCard name="react" />
         <IconCard name="loading" />
+        <IconCard name="loading" inverted />
       </div>
     </React.Fragment>
   )

--- a/packages/orion/src/Icon/Icon.stories.js
+++ b/packages/orion/src/Icon/Icon.stories.js
@@ -27,7 +27,8 @@ export const customIcons = () => {
     )
   }
   IconCard.propTypes = {
-    name: PropTypes.string
+    name: PropTypes.string,
+    inverted: PropTypes.bool
   }
 
   return (

--- a/packages/orion/src/Icon/icon.css
+++ b/packages/orion/src/Icon/icon.css
@@ -25,14 +25,14 @@ i.orion.icon.loading:after {
 }
 
 i.orion.icon.loading:before {
-  @apply border-gray-900-16;
+  border-color: #e3e4e5;
 }
 
 i.orion.icon.loading:after {
   animation: orionLoading 0.6s linear;
   animation-iteration-count: infinite;
 
-  border-color: #616263 transparent transparent;
+  border-color: #9e9fa0 transparent transparent;
 }
 
 @keyframes orionLoading {


### PR DESCRIPTION
No `Inloco` a gente precisou usar o `loading icon` com o background mais escuro... aí ficou bem ruim..

Depois de fazer vários ajustes com @brunoperruci-inloco , encontramos as cores corretas pra ambos os backgrounds:
![2020-09-16 16 27 50](https://user-images.githubusercontent.com/1139664/93384448-3ab63500-f83b-11ea-9959-b34b31629284.gif)

