### PR TITLE
fix(dropdown): Fix dropdown multiple checkbox click

### DIFF
--- a/packages/orion/src/Dropdown/DropdownItem/index.js
+++ b/packages/orion/src/Dropdown/DropdownItem/index.js
@@ -18,7 +18,7 @@ const DropdownItem = ({
 
   if (!children) {
     children = (
-      <div className="flex items-center">
+      <div className="flex items-center pointer-events-none">
         <Checkbox checked={active} />
 
         {image && (


### PR DESCRIPTION
Tinha um bug cabuloso no Dropdown múltiplo com checkbox...

Se o Dropdown tiver uma `max-height` para os itens, e você clicar em cima do checkbox, o scroll subia pro primeiro item.

ex:
![2020-09-25 16 51 26](https://user-images.githubusercontent.com/1139664/94310144-8a89b000-ff4f-11ea-99b4-2293dad0a55a.gif)

Aí adicionei um `user-events-none` pra que os clicks dentro do checkbox não sejam reportados, já que temos um evento de click no wrapper do item.

Depois:
![2020-09-25 16 52 14](https://user-images.githubusercontent.com/1139664/94310152-8eb5cd80-ff4f-11ea-9b3f-18b8b4d9b992.gif)

