### PR TITLE
fix(package.json): add assets to "files" paths

### DIFF
--- a/packages/orion/package.json
+++ b/packages/orion/package.json
@@ -3,7 +3,8 @@
   "version": "1.35.0",
   "description": "Semantic-UI Toolkit - In Loco theme",
   "files": [
-    "**/*.js",
+    "dist/**/*.js",
+    "dist/assets/*",
     "dist/orion.css",
     "dist/orion.min.css"
   ],


### PR DESCRIPTION
No último release, o componente de Flags não funcionou pq o arquivo `.png` com os sprites não foi incluído no pacote. Então adicionei o path para `assets` no `files` do `package.json`.
Also, percebi o path `**/*.js` estava fazendo incluir alguns `.js` [que eu acho que são] desnecessários no bundle, como os arquivos em `src` (o que se usa de fato está em `dist`) e alguns arquivos de configuração no ambiente de dev.
![Capture d’écran 2020-09-28 à 14 56 32](https://user-images.githubusercontent.com/9112403/94468754-530f4380-019b-11eb-9dc0-1fafedc4e45e.png)

Então atualizei para incluir apenas os `.js` dentro de `/dist`, esta mudança faz sentido?

Eu não sei alguma forma de testar se isso ficou okay além de fazer de fato o release do pacote no npm. Vocês têm alguma ideia de como eu posso gerar e inspecionar este bundle localmente, sem precisar fazer um release real?