### PR TITLE
Fix/search input padding

### DIFF
--- a/packages/orion/src/Form/Field/field.css
+++ b/packages/orion/src/Form/Field/field.css
@@ -22,6 +22,7 @@
 }
 
 .orion.form .field.floatingLabel label:not(:empty) + .dropdown > .text,
+.orion.form .field.floatingLabel label:not(:empty) + .dropdown > .search,
 .orion.form .field.floatingLabel label:not(:empty) + .input > input,
 .orion.form
   .field.floatingLabel:not(.filled)

--- a/packages/orion/src/Form/Form.stories.js
+++ b/packages/orion/src/Form/Form.stories.js
@@ -18,11 +18,11 @@ export default {
 export const subcomponents = () => (
   <Form>
     <Form.Field message={text('Message', '')}>
-      <label htmlFor="fullName">{text('Input label', 'Full Name')}</label>
+      <label htmlFor="fullName">{text('Label', 'Full Name', 'Input')}</label>
       <Input
         fluid={boolean('Fluid', false)}
         id="fullName"
-        placeholder={text('Input placeholder', 'Enter your full name')}
+        placeholder={text('Placeholder', 'Enter your full name', 'Input')}
         size={sizeKnob()}
         warning={boolean('Warning', false)}
         error={boolean('Error', false)}
@@ -30,26 +30,29 @@ export const subcomponents = () => (
       />
     </Form.Field>
     <Form.Field message={text('Message', '')}>
-      <label htmlFor="buddy">{text('Dropdown label', 'Buddy')}</label>
+      <label htmlFor="buddy">{text('Label', 'Buddy', 'Dropdown')}</label>
       <Dropdown
         selection
         id="buddy"
         fluid={boolean('Fluid', false)}
-        placeholder={text('Dropdown placeholder', 'Choose your buddy')}
-        options={object('Dropdown options', developerOptions)}
+        search={boolean('Search', false, 'Dropdown')}
+        placeholder={text('Placeholder', 'Choose your buddy', 'Dropdown')}
+        options={object('Options', developerOptions, 'Dropdown')}
         warning={boolean('Warning', false)}
         error={boolean('Error', false)}
         size={sizeKnob()}
       />
     </Form.Field>
     <Form.Field message={text('Message', '')}>
-      <label htmlFor="date">{text('DatepickerInput label', 'Date')}</label>
+      <label htmlFor="date">{text('Label', 'Date', 'Datepicker')}</label>
       <DatepickerInput
         id="date"
         fluid={boolean('Fluid', false)}
         message={text('Message', '')}
-        placeholder={text('Date picker placeholder', 'Choose a date')}
+        placeholder={text('Placeholder', 'Choose a date', 'Datepicker')}
         warning={boolean('Warning', false)}
+        error={boolean('Error', false)}
+        size={sizeKnob()}
       />
     </Form.Field>
     <Form.Field message={text('Message', '')}>


### PR DESCRIPTION
O componente de "Search" dentro do form não estava com o padding para se adequar à label flutuante, então adicionei. Aproveitei pra reorganizar os knobs do storybook pra agrupá-los de acordo com cada Input do Form.

Antes:
![Capture d’écran 2020-09-28 à 17 03 51](https://user-images.githubusercontent.com/9112403/94481528-39c3c280-01ae-11eb-9ec2-1d8758a58de6.png)

Depois:
![Capture d’écran 2020-09-28 à 17 04 10](https://user-images.githubusercontent.com/9112403/94481541-3b8d8600-01ae-11eb-875a-c890bd978ed4.png)
