### PR TITLE
fix(dropdown): Clicking on the checkbox

### DIFF
--- a/packages/orion/src/Dropdown/DropdownItem/index.js
+++ b/packages/orion/src/Dropdown/DropdownItem/index.js
@@ -19,8 +19,8 @@ const DropdownItem = ({
 
   if (!children) {
     children = (
-      <div className="flex items-center pointer-events-none">
-        <Checkbox checked={active} />
+      <div className="flex items-center">
+        <Checkbox checked={active} className="pointer-events-none" />
         {flag && <Flag name={flag} />}
         {image && (
           <div className="flex-shrink-0">


### PR DESCRIPTION
Em um PR passado ([PR-883](https://github.com/inloco/orion/pull/883)), eu tinha colocado o `pointer-events-none` no div inteiro responsável pelo DropdownItem.

Isto causou um efeito colateral no `Inloco`, onde havia um conteúdo com o evento de click configurado.

Na verdade eu só preciso desconsiderar o evento do click no checkbox em si.

