### PR TITLE
feature(status-tag): Add large size

### DIFF
--- a/packages/orion/src/StatusTag/StatusTag.stories.js
+++ b/packages/orion/src/StatusTag/StatusTag.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { text, boolean } from '@storybook/addon-knobs'
 
-import { sizeKnob } from '../utils/stories'
-import { Sizes } from '../utils/sizes'
+import { threeSizesKnob } from '../utils/stories'
+import { ThreeSizes } from '../utils/sizes'
 import { StatusTag, Icon } from '..'
 
 export default {
@@ -10,7 +10,7 @@ export default {
 }
 
 export const inactive = () => {
-  const size = sizeKnob(Sizes.SMALL)
+  const size = threeSizesKnob(ThreeSizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
   const icon = text('Icon', 'remove_circle')
@@ -28,7 +28,7 @@ export const inactive = () => {
 }
 
 export const neutral = () => {
-  const size = sizeKnob(Sizes.SMALL)
+  const size = threeSizesKnob(ThreeSizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
   const icon = text('Icon', 'info')
@@ -46,7 +46,7 @@ export const neutral = () => {
 }
 
 export const warning = () => {
-  const size = sizeKnob(Sizes.SMALL)
+  const size = threeSizesKnob(ThreeSizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
   const icon = text('Icon', 'warning')
@@ -64,7 +64,7 @@ export const warning = () => {
 }
 
 export const error = () => {
-  const size = sizeKnob(Sizes.SMALL)
+  const size = threeSizesKnob(ThreeSizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
   const icon = text('Icon', 'error')
@@ -82,7 +82,7 @@ export const error = () => {
 }
 
 export const success = () => {
-  const size = sizeKnob(Sizes.SMALL)
+  const size = threeSizesKnob(ThreeSizes.SMALL)
   const bordered = boolean('Bordered', true)
   const filled = boolean('Filled', false)
   const icon = text('Icon', 'check_circle')

--- a/packages/orion/src/StatusTag/statusTag.css
+++ b/packages/orion/src/StatusTag/statusTag.css
@@ -12,6 +12,10 @@
   height: 20px;
 }
 
+.orion.status-tag.large {
+  @apply h-32 px-16 py-8;
+}
+
 .orion.status-tag.bordered {
   @apply border;
 }

--- a/packages/orion/src/utils/sizes.js
+++ b/packages/orion/src/utils/sizes.js
@@ -5,4 +5,14 @@ export const Sizes = {
   SMALL: 'small'
 }
 
+export const ThreeSizes = {
+  ...Sizes,
+  LARGE: 'large'
+}
+
 export const sizePropType = PropTypes.oneOf([Sizes.DEFAULT, Sizes.SMALL])
+export const threeSizesPropType = PropTypes.oneOf([
+  ThreeSizes.DEFAULT,
+  ThreeSizes.SMALL,
+  ThreeSizes.LARGE
+])

--- a/packages/orion/src/utils/stories.js
+++ b/packages/orion/src/utils/stories.js
@@ -1,11 +1,23 @@
 import { radios } from '@storybook/addon-knobs'
 
-import { Sizes } from './sizes'
+import { Sizes, ThreeSizes } from './sizes'
 
 export const sizeKnob = (defaultValue = Sizes.DEFAULT, groupId) =>
   radios(
     'Size',
     { Default: Sizes.DEFAULT, Small: Sizes.SMALL },
+    defaultValue,
+    groupId
+  )
+
+export const threeSizesKnob = (defaultValue = ThreeSizes.DEFAULT, groupId) =>
+  radios(
+    'Size',
+    {
+      Default: ThreeSizes.DEFAULT,
+      Small: ThreeSizes.SMALL,
+      Large: ThreeSizes.LARGE
+    },
     defaultValue,
     groupId
   )


### PR DESCRIPTION
Tem um StatusTag maior agora.

![2020-10-21 17 57 19](https://user-images.githubusercontent.com/1139664/96786797-22e84880-13c7-11eb-93e0-5353882f0195.gif)


Eu adicionei um `size='large'`.

Como é o primeiro componente com `size='large'`. Eu precisei criar outras constantes de sizes (`ThreeSizes`), pra não interferir nos outros componentes que já usam as constantes atuais.

Se alguém tiver uma idéia melhor...
