### PR TITLE
fix(popup): Remove line-height 14

### DIFF
--- a/packages/orion/src/Popup/popup.css
+++ b/packages/orion/src/Popup/popup.css
@@ -1,5 +1,5 @@
 .orion.popup {
-  @apply bg-white border border-gray-900-8 leading-14 max-w-384 p-16 rounded shadow-300 text-gray-800 z-50;
+  @apply bg-white border border-gray-900-8 max-w-384 p-16 rounded shadow-300 text-gray-800 z-50;
 }
 
 .orion.popup:before {


### PR DESCRIPTION
Falei com Bruno, e ele disse que não tem mais o line-height de 14 no Popup/InfoIcon.

Antes:
![image](https://user-images.githubusercontent.com/1139664/97192713-ecc01580-1786-11eb-8f93-2a961c4988c9.png)

Depois:
![image](https://user-images.githubusercontent.com/1139664/97192734-f5b0e700-1786-11eb-8275-fd86d9630cc7.png)
