### PR TITLE
feature(scroll-y): Always show scroll vertically

### DIFF
--- a/packages/atomic-bomb/css/base.css
+++ b/packages/atomic-bomb/css/base.css
@@ -6,7 +6,7 @@
 }
 
 body {
-  @apply font-default text-gray-900 leading-20 text-base;
+  @apply font-default text-gray-900 leading-20 text-base overflow-y-scroll;
 }
 
 h1,

--- a/packages/atomic-bomb/css/base.css
+++ b/packages/atomic-bomb/css/base.css
@@ -6,7 +6,7 @@
 }
 
 body {
-  @apply font-default text-gray-900 leading-20 text-base overflow-y-scroll;
+  @apply font-default text-gray-900 leading-20 text-base;
 }
 
 h1,

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -20,6 +20,7 @@
   @apply fixed top-0 left-0 z-40;
   @apply flex-shrink-0 items-center h-64 bg-white;
   @apply border-b-1 border-gray-900-16;
+  padding-left: calc(100vw - 100%);
 }
 
 .orion.layout .layout-topbar.dimmed {
@@ -44,6 +45,7 @@
  */
 .orion.layout .layout-main {
   @apply flex-1 py-24 mt-64;
+  padding-left: calc(100vw - 100%);
 }
 
 /**


### PR DESCRIPTION
Olá!

Bruno me pediu através deste card: https://www.notion.so/inlocoglobal/Feature-review-c81b47283400497d9c26c51ee5e60fd2?p=a33b5009d0394982b8f6c93d5b77d15d

para sempre mostrar o scroll vertical, independente do conteúdo.

Ficou assim:
![image](https://user-images.githubusercontent.com/1139664/98022022-d5ff6b80-1de3-11eb-98fe-e56a91c85e8f.png)


Isto é pra evitar o "samba" que acontece quando muda de uma tela que não tem scroll pra uma tela que tem.

Achei esquisito, então qualquer coisa, reclame com ele 😆 

**Update 17:39**

@TCezarRod sugeriu uma solução melhor, e subi o ajuste!!!
