### PR TITLE
feat(Dialog): change info icon to outline

### DIFF
--- a/packages/orion/src/Dialog/dialog.css
+++ b/packages/orion/src/Dialog/dialog.css
@@ -20,7 +20,7 @@
 
 .orion.modal.dialog > .header::before {
   @apply font-icons mb-8 text-icon-md text-space-600;
-  content: 'info';
+  content: 'info_outline';
 }
 
 /*--------------


### PR DESCRIPTION
Atualmente o Dialog está com o ícone sólido para o estado default
![Capture d’écran 2020-11-19 à 17 23 41](https://user-images.githubusercontent.com/9112403/99720638-c727e280-2a8c-11eb-8b7d-e8f5d6488269.png)

Mas no Invision, está definido para usar o ícone outlined. Então estou trocando e agora está assim:
![Capture d’écran 2020-11-19 à 17 28 11](https://user-images.githubusercontent.com/9112403/99720655-d313a480-2a8c-11eb-906e-70484a8dcef4.png)
