### PR TITLE
feature(Pagination): Add language param

### DIFF
--- a/packages/orion/src/Pagination/Pagination.stories.js
+++ b/packages/orion/src/Pagination/Pagination.stories.js
@@ -21,10 +21,11 @@ export const basic = () => (
   <Pagination
     activePage={number('activePage', 1)}
     disabled={boolean('disabled', false)}
-    totalItems={number('totalItems', 232)}
+    totalItems={number('totalItems', 29382)}
     pageSize={number('pageSize', 15)}
     alignButtonsLeft={boolean('alignButtonsLeft', false)}
     i18n={object('i18n', {
+      language: 'en',
       of: 'of',
       results: 'results'
     })}

--- a/packages/orion/src/Pagination/index.js
+++ b/packages/orion/src/Pagination/index.js
@@ -63,7 +63,9 @@ const Pagination = ({
               {firstPageItem}-{lastPageItem}
             </span>
             <span className="orion-pagination-text">{i18n.of}</span>
-            <span className="orion-pagination-value">{totalItems}</span>
+            <span className="orion-pagination-value">
+              {totalItems.toLocaleString(i18n.language)}
+            </span>
           </>
         )}
         <span className="orion-pagination-text">{i18n.results}</span>
@@ -107,6 +109,7 @@ Pagination.propTypes = {
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
   i18n: PropTypes.shape({
+    language: PropTypes.string,
     of: PropTypes.string,
     results: PropTypes.string
   }),
@@ -121,6 +124,7 @@ Pagination.propTypes = {
 Pagination.defaultProps = {
   activePage: 1,
   i18n: {
+    language: 'en',
     of: 'of',
     results: 'results'
   },


### PR DESCRIPTION
Adicionando o i18n.language no Pagination, pra a gente poder formatar o totalItems:

![image](https://user-images.githubusercontent.com/1139664/99847326-ac21a500-2b56-11eb-9a2b-db0621b5f3f2.png)

O TotalItems não pode ser uma string, porque é feito um calculo em cima dele, então a formatação tem que ser feita no Orion mesmo.