### PR TITLE
Feature/remove fit-content

### DIFF
--- a/packages/orion/src/DatepickerInput/datepickerInput.css
+++ b/packages/orion/src/DatepickerInput/datepickerInput.css
@@ -3,7 +3,7 @@
 }
 
 .datepicker-input-trigger {
-  width: fit-content;
+  @apply inline-block w-auto;
 }
 
 .datepicker-input-trigger.fluid {

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -77,7 +77,6 @@
 .orion.layout .layout-apps-dropdown > .menu {
   @apply bg-gray-100 left-0;
   min-width: 206px;
-  width: fit-content;
   transform: translateX(calc(-50% + 20px));
 }
 

--- a/packages/orion/src/StatusTag/statusTag.css
+++ b/packages/orion/src/StatusTag/statusTag.css
@@ -3,9 +3,8 @@
 *******************************/
 
 .orion.status-tag {
-  @apply flex text-sm h-24;
+  @apply inline-flex text-sm h-24 w-auto;
   @apply rounded-full bg-transparent;
-  width: fit-content;
 }
 
 .orion.status-tag.small {


### PR DESCRIPTION
O valor `fit-content` para `width` é experimental e não é suportada em alguns browsers
https://developer.mozilla.org/pt-BR/docs/Web/CSS/width

Então estou removendo a regra de onde faltava aqui no Orion.
No `Layout` o `fit-content` era desnecessário, o dropdown de apps funciona sem ele
![Capture d’écran 2020-12-01 à 12 01 23](https://user-images.githubusercontent.com/9112403/100757442-25c65800-33cd-11eb-8833-69c4d862e3ac.png)

No `StatusTag` e `DatePickerInput`, susbstituí por `w-auto`. Para isso, precisei trocar o display para um `inline` (flex ou block). Antes de fazer isso, chequei no `inloco-frontend` e no `4apps-js` se essa mudança no display influenciaria em algo. Mas está tudo certo. Só o `StatusTag` está sendo usado nos projetos, e a mudança não traz problemas. O `DatePicker` não é usado em nenhum dos dois projetos.
![Capture d’écran 2020-12-01 à 12 01 15](https://user-images.githubusercontent.com/9112403/100757608-58705080-33cd-11eb-8557-7e474b15169e.png)
![Capture d’écran 2020-12-01 à 12 00 59](https://user-images.githubusercontent.com/9112403/100757609-5908e700-33cd-11eb-9b12-ce799d4db323.png)
