### PR TITLE
Chore/update semantic ui to 2.0.1

### DIFF
--- a/packages/orion/package.json
+++ b/packages/orion/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://inloco.github.io/orion",
   "dependencies": {
     "@inloco/atomic-bomb": "^1.3.2",
-    "@inloco/semantic-ui-react": "^0.88.2",
+    "@inloco/semantic-ui-react": "^2.0.1-orion",
     "body-scroll-lock": "^3.0.2",
     "classnames": "^2.2.6",
     "keyboard-key": "^1.0.4",

--- a/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
+++ b/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
@@ -19,7 +19,8 @@
   @apply mt-4 leading-14 text-gray-800 text-sm;
 }
 
-.orion.dropdown .menu > .item .image {
+.orion.dropdown .menu > .item .image,
+.orion.dropdown .label-text > .image {
   @apply mr-8 rounded-full border border-gray-900-8 w-24 h-24;
 }
 

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -227,3 +227,11 @@
 .orion.dropdown .menu > .divider {
   @apply border-t border-gray-900-16;
 }
+
+/**
+ * Label text
+ */
+
+.orion.dropdown .label-text {
+  @apply flex items-center;
+}

--- a/packages/orion/src/Dropdown/dropdown.css
+++ b/packages/orion/src/Dropdown/dropdown.css
@@ -131,6 +131,10 @@
   @apply hidden;
 }
 
+.orion.dropdown.multiple.search > .label ~ .text {
+  @apply hidden;
+}
+
 /**
  * Search + Multiple
  */

--- a/packages/orion/src/Popup/popup.css
+++ b/packages/orion/src/Popup/popup.css
@@ -35,13 +35,13 @@
 
 .orion.popup.top:before {
   @apply top-auto right-auto;
-  bottom: -6px;
+  bottom: 6px;
   box-shadow: 1px 1px 0 0 rgba(61, 62, 63, 0.08);
 }
 
 .orion.popup.bottom:before {
   @apply bottom-auto right-auto;
-  top: -6px;
+  top: 6px;
   box-shadow: -1px -1px 0 0 rgba(61, 62, 63, 0.08);
 }
 
@@ -64,19 +64,19 @@
 .orion.popup.left.center:before,
 .orion.popup.right.center:before {
   @apply bottom-auto;
-  margin-top: -6px;
+  margin-top: 6px;
   top: 50%;
 }
 
 .orion.popup.left.center:before {
-  @apply left-auto;
-  right: -6px;
+  @apply left-auto top-auto;
+  right: 3px;
   box-shadow: 1px -1px 0 0 rgba(61, 62, 63, 0.08);
 }
 
 .orion.popup.right.center:before {
-  @apply right-auto;
-  left: -6px;
+  @apply right-auto top-auto;
+  left: 3px;
   box-shadow: -1px 1px 0 0 rgba(61, 62, 63, 0.08);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,7 +1572,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.5":
+"@babel/runtime@^7.10.4", "@babel/runtime@^7.10.5", "@babel/runtime@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -1904,6 +1904,21 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fluentui/react-component-event-listener@~0.51.1":
+  version "0.51.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.3.tgz#c1e64244eefb1802930eb6e74cc046775d257315"
+  integrity sha512-ngRG5XUgX5tsN79Rkwaxaon8U79bUO8GRKnN1bc3WQl6cYVrL6XFdgc09/a/ISK53/sS6oa2wZ/csNTwvkDO4Q==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+
+"@fluentui/react-component-ref@~0.51.1":
+  version "0.51.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-component-ref/-/react-component-ref-0.51.3.tgz#d8a2d87e5830d8da048072d7c615a94364bb5dca"
+  integrity sha512-6+DhceCb+4ua3WVoOW99aniEaFlfrlBs9kuCs6BJEcAeqYMoa2VFzxkPWXH/35a73LKIeLsHwoLXyOsILuYRRw==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    react-is "^16.6.3"
+
 "@fullhuman/postcss-purgecss@^2.1.2":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.2.0.tgz#2b3699287163ff515f25ccdae5b96a244eebb41a"
@@ -1920,21 +1935,23 @@
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
 
-"@inloco/semantic-ui-react@^0.88.2":
-  version "0.88.2"
-  resolved "https://registry.yarnpkg.com/@inloco/semantic-ui-react/-/semantic-ui-react-0.88.2.tgz#bc0387f120b6d4f83476b087055e2fdfc87dd81c"
-  integrity sha512-5t4cBDkGDyx8LSeb/QGrqspzmPbOzPslQYcJNLrmx/mQRwTVXErYfO9FA4iJ+9sVLqQVi4r/1nij1WHI3OOorg==
+"@inloco/semantic-ui-react@^2.0.1-orion":
+  version "2.0.1-orion"
+  resolved "https://registry.yarnpkg.com/@inloco/semantic-ui-react/-/semantic-ui-react-2.0.1-orion.tgz#d875e3cc7f6dc4ebb6eefa4f69c1f654f9ce83e9"
+  integrity sha512-FQs+RvkfLKWE9Y71NlPghKunLdda3hDcLVvLkoho/qZLVMQ70ocdZ/5q04eE8So+QkFgyjtYCTnEpB+cuKYXdA==
   dependencies:
-    "@babel/runtime" "^7.1.2"
+    "@babel/runtime" "^7.10.5"
+    "@fluentui/react-component-event-listener" "~0.51.1"
+    "@fluentui/react-component-ref" "~0.51.1"
+    "@popperjs/core" "^2.5.2"
     "@semantic-ui-react/event-stack" "^3.1.0"
-    "@stardust-ui/react-component-event-listener" "~0.38.0"
-    "@stardust-ui/react-component-ref" "~0.38.0"
-    classnames "^2.2.6"
-    keyboard-key "^1.0.4"
-    lodash "^4.17.15"
+    clsx "^1.1.1"
+    keyboard-key "^1.1.0"
+    lodash "^4.17.19"
+    lodash-es "^4.17.15"
     prop-types "^15.7.2"
     react-is "^16.8.6"
-    react-popper "^1.3.4"
+    react-popper "^2.2.3"
     shallowequal "^1.1.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
@@ -2906,7 +2923,7 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.4.4", "@popperjs/core@^2.5.4":
+"@popperjs/core@^2.4.4", "@popperjs/core@^2.5.2", "@popperjs/core@^2.5.4":
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
   integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
@@ -2946,21 +2963,6 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
-
-"@stardust-ui/react-component-event-listener@~0.38.0":
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/@stardust-ui/react-component-event-listener/-/react-component-event-listener-0.38.0.tgz#1787faded94b40ad41226e6289baf13e701c6e7f"
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    prop-types "^15.7.2"
-
-"@stardust-ui/react-component-ref@~0.38.0":
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/@stardust-ui/react-component-ref/-/react-component-ref-0.38.0.tgz#52d555f2d5edd213c923c93a106f7de940e427ef"
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    prop-types "^15.7.2"
-    react-is "^16.6.3"
 
 "@storybook/addon-actions@^6.0.22":
   version "6.0.22"
@@ -3830,7 +3832,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@17.0.0", "@types/react-dom@^17.0.0":
+"@types/react-dom@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
   integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
@@ -3844,7 +3846,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.9.34", "@types/react@^16.9.34":
+"@types/react@*", "@types/react@^16.9.34":
   version "16.9.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
   integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
@@ -10579,7 +10581,7 @@ just-debounce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.0.0.tgz#87fccfaeffc0b68cd19d55f6722943f929ea35ea"
 
-keyboard-key@^1.0.4:
+keyboard-key@^1.0.4, keyboard-key@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keyboard-key/-/keyboard-key-1.1.0.tgz#6f2e8e37fa11475bb1f1d65d5174f1b35653f5b7"
   integrity sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ==
@@ -10823,6 +10825,11 @@ locate-path@^5.0.0:
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -13604,17 +13611,6 @@ react-popper-tooltip@^3.1.0:
     "@popperjs/core" "^2.5.4"
     react-popper "^2.2.4"
 
-react-popper@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.4.tgz#f0cd3b0d30378e1f663b0d79bcc8614221652ced"
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    create-react-context "^0.3.0"
-    popper.js "^1.14.4"
-    prop-types "^15.6.1"
-    typed-styles "^0.0.7"
-    warning "^4.0.2"
-
 react-popper@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"
@@ -13628,7 +13624,7 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-popper@^2.2.4:
+react-popper@^2.2.3, react-popper@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.4.tgz#d2ad3d2474ac9f1abf93df3099d408e5aa6a2e22"
   integrity sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==


### PR DESCRIPTION
Eu quebrei em commits e acho que facilita revisando por eles:

1. Faz o upgrade pra v2.0.1 do semantic.
2. Atualiza o dropdown múltiplo com imagens. No antigo, o item selecionado não ficava com a imagem, agora fica:
![image](https://user-images.githubusercontent.com/1139664/101026583-d8292700-3555-11eb-93c4-e83f9d260ad0.png)

3. Ajustei o `pointing` do Popup / Tooltip / Derivados... 
![image](https://user-images.githubusercontent.com/1139664/101026703-fb53d680-3555-11eb-86ae-9415032a24f3.png)

4. No dropdown, precisamos esconder o placeholder quando o item tá selecionado. No anterior o placeholder era removido.

OBS: Passei de componente em componente, e fiz alguns testes, mas pode ser que tenha escapado alguma coisa, ou então que o uso de um componente no `inloco-frontend` ou `4apps-js` faça ele se comportar diferente. Fiquem atentos caso encontrem algo estranho.

