### PR TITLE
feat(Dropdown): add disabled style for items

### DIFF
--- a/packages/orion/src/Dropdown/Dropdown.stories.js
+++ b/packages/orion/src/Dropdown/Dropdown.stories.js
@@ -16,8 +16,8 @@ const actions = {
 
 const developerOptions = [
   { text: 'Francisco Gileno', value: 1 },
-  { text: 'Rafael Nunes', value: 2 },
-  { text: 'Maíra Bello', value: 3 }
+  { text: 'Rafael Nunes', value: 2, disabled: true },
+  { text: 'Maíra Bello', value: 3, disabled: true }
 ]
 
 export default {

--- a/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
+++ b/packages/orion/src/Dropdown/DropdownItem/dropdown-item.css
@@ -15,6 +15,10 @@
   @apply bg-gray-100;
 }
 
+.orion.dropdown .menu > .item.disabled {
+  @apply cursor-default opacity-32;
+}
+
 .orion.dropdown .menu > .item .description {
   @apply mt-4 leading-14 text-gray-800 text-sm;
 }


### PR DESCRIPTION
O Dropdown.Item dá suporte ao `disabled` mas ainda não tínhamos adicionado o estilo. Estou fazendo-o aqui
![orion-disabled-](https://user-images.githubusercontent.com/9112403/101386128-7d683600-389b-11eb-9b75-e5c3fb5dfba7.gif)

No GIF não dá pra perceber, mas eu estava clicando nos itens disabled. Apenas o que não está desabilitado gera eventos.