### PR TITLE
Feature/Layout alert

### DIFF
--- a/packages/orion/src/Layout/Layout.js
+++ b/packages/orion/src/Layout/Layout.js
@@ -1,0 +1,24 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { useAlert } from './LayoutAlert'
+
+const Layout = ({ className, children, ...otherProps }) => {
+  const alert = useAlert()
+  const classes = cx('orion layout', className, {
+    'with-alert': !!alert
+  })
+  return (
+    <div className={classes} {...otherProps}>
+      {children}
+    </div>
+  )
+}
+
+Layout.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node
+}
+
+export default Layout

--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -15,6 +15,10 @@ const storyMetadata = {
 
 export default storyMetadata
 
+const paragraphs = _.times(10, () =>
+  loremIpsum({ count: 1, units: 'paragraph' })
+)
+
 export const basic = () => (
   <Layout className="absolute left-0 top-0 w-full">
     <Layout.Topbar dimmed={boolean('Dimmed', false, 'Topbar')}>
@@ -97,8 +101,11 @@ export const basic = () => (
       </Layout.UserProfile>
     </Layout.Topbar>
     <Layout.Main>
-      {_.times(10, index => (
-        <p key={index}>{loremIpsum({ count: 1, units: 'paragraph' })}</p>
+      {boolean('Enabled', true, 'Alert') && (
+        <Layout.Alert message={text('Message', 'This is an Alert', 'Alert')} />
+      )}
+      {_.map(paragraphs, (paragraph, index) => (
+        <p key={index}>{paragraph}</p>
       ))}
     </Layout.Main>
   </Layout>

--- a/packages/orion/src/Layout/LayoutAlert/Alert.tsx
+++ b/packages/orion/src/Layout/LayoutAlert/Alert.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import Icon from '../../Icon'
+
+const Alert: React.FC<AlertProps> = ({ alert }) => {
+  return (
+    <div className="layout-alert">
+      <Icon name="warning" />
+      {alert}
+    </div>
+  )
+}
+
+interface AlertProps {
+  alert: string
+}
+
+export default Alert

--- a/packages/orion/src/Layout/LayoutAlert/index.tsx
+++ b/packages/orion/src/Layout/LayoutAlert/index.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useState, useEffect } from 'react'
+
+import Alert from './Alert'
+
+const AlertContext: React.Context<ContextValue> = createContext(
+  {} as ContextValue
+)
+
+const AlertContextProvider: React.FC = props => {
+  const [message, setMessage] = useState<string | null>(null)
+
+  return <AlertContext.Provider value={{ message, setMessage }} {...props} />
+}
+
+const LayoutAlert: React.FC<LayoutAlertProps> = ({ message }) => {
+  const { setMessage } = useContext(AlertContext)
+
+  useEffect(() => {
+    setMessage(message)
+
+    return () => setMessage(null)
+  }, [message])
+  return null
+}
+
+function useAlert(): string | null {
+  const { message } = useContext(AlertContext)
+
+  return message
+}
+
+interface ContextValue {
+  message: string | null
+  setMessage: React.Dispatch<React.SetStateAction<string | null>>
+}
+
+interface LayoutAlertProps {
+  message: string
+}
+
+export default LayoutAlert
+export { AlertContextProvider, useAlert, Alert }

--- a/packages/orion/src/Layout/LayoutTopbar/index.js
+++ b/packages/orion/src/Layout/LayoutTopbar/index.js
@@ -5,13 +5,16 @@ import React from 'react'
 import TopbarDivider from './TopbarDivider'
 import LayoutCenter from '../LayoutCenter'
 import Logo from '../../Logo'
+import { Alert, useAlert } from '../LayoutAlert'
 
 const LayoutTopbar = ({ className, children, logo, dimmed, ...otherProps }) => {
   const classes = cx('layout-topbar', { dimmed }, className)
+  const alert = useAlert()
   return (
     <LayoutCenter className={classes} {...otherProps}>
       {logo || <Logo className="mb-4" />}
       {children}
+      {alert && <Alert alert={alert} />}
     </LayoutCenter>
   )
 }

--- a/packages/orion/src/Layout/index.js
+++ b/packages/orion/src/Layout/index.js
@@ -8,6 +8,11 @@ import LayoutMain from './LayoutMain'
 import LayoutTopbar from './LayoutTopbar'
 import LayoutUserProfile from './LayoutUserProfile'
 
+const Dimensions = {
+  topbarHeight: 64,
+  alertHeight: 40
+}
+
 const LayoutIndex = props => {
   return (
     <AlertContextProvider>
@@ -22,5 +27,6 @@ LayoutIndex.Center = LayoutCenter
 LayoutIndex.Main = LayoutMain
 LayoutIndex.Topbar = LayoutTopbar
 LayoutIndex.UserProfile = LayoutUserProfile
+LayoutIndex.Dimensions = Dimensions
 
 export default LayoutIndex

--- a/packages/orion/src/Layout/index.js
+++ b/packages/orion/src/Layout/index.js
@@ -1,31 +1,26 @@
-import cx from 'classnames'
-import PropTypes from 'prop-types'
 import React from 'react'
 
+import Layout from './Layout'
+import LayoutAlert, { AlertContextProvider } from './LayoutAlert'
 import LayoutAppsDropdown from './LayoutAppsDropdown'
 import LayoutCenter from './LayoutCenter'
 import LayoutMain from './LayoutMain'
 import LayoutTopbar from './LayoutTopbar'
 import LayoutUserProfile from './LayoutUserProfile'
 
-const Layout = ({ className, children, ...otherProps }) => {
-  const classes = cx('orion layout', className)
+const LayoutIndex = props => {
   return (
-    <div className={classes} {...otherProps}>
-      {children}
-    </div>
+    <AlertContextProvider>
+      <Layout {...props} />
+    </AlertContextProvider>
   )
 }
 
-Layout.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node
-}
+LayoutIndex.Alert = LayoutAlert
+LayoutIndex.AppsDropdown = LayoutAppsDropdown
+LayoutIndex.Center = LayoutCenter
+LayoutIndex.Main = LayoutMain
+LayoutIndex.Topbar = LayoutTopbar
+LayoutIndex.UserProfile = LayoutUserProfile
 
-Layout.AppsDropdown = LayoutAppsDropdown
-Layout.Center = LayoutCenter
-Layout.Main = LayoutMain
-Layout.Topbar = LayoutTopbar
-Layout.UserProfile = LayoutUserProfile
-
-export default Layout
+export default LayoutIndex

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -49,7 +49,8 @@
 }
 
 .orion.layout.with-alert .layout-main {
-  margin-top: 98px;
+  /* topbar + alert = 64px + 40px*/
+  margin-top: 104px;
 }
 
 /**

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -48,6 +48,10 @@
   padding-left: calc(100vw - 100%);
 }
 
+.orion.layout.with-alert .layout-main {
+  margin-top: 98px;
+}
+
 /**
  * Apps Dropdown Trigger
  */
@@ -113,4 +117,14 @@
 
 .orion.layout .layout-apps-dropdown-image > .orion.image {
   @apply mx-0;
+}
+
+.orion.layout .layout-alert {
+  @apply fixed left-0 flex justify-center bg-yellow-50 leading-20 w-screen;
+  top: 64px;
+  padding: 10px 0;
+}
+
+.orion.layout .layout-alert > .icon {
+  @apply text-yellow-500 mr-4;
 }


### PR DESCRIPTION
Adicionando um componente de Alerta que adiciona um banner no topo do layout

Para evitar nos preocuparmos com o posicionamento na hora de usar, deixei o compoennte renderizado de fato em uma posição fixa logo abaixo da Topbar.
O componente exportado do Orion na vdd apenas seta a mensagem num Context. Então ele pode ser chamado em qualquer lugar dentro do `Layout`

![Layout alert](https://user-images.githubusercontent.com/9112403/107544850-67cc0100-6ba9-11eb-85d0-9fe8cd792d3a.gif)
