### PR TITLE
feat(Datepicker): set nav buttons as subtle

### DIFF
--- a/packages/orion/src/Datepicker/ReactDatesDatepicker/index.js
+++ b/packages/orion/src/Datepicker/ReactDatesDatepicker/index.js
@@ -10,8 +10,8 @@ const ReactDatesDatepicker = ({ as: ElementType, ...otherProps }) => (
     hideKeyboardShortcutsPanel
     horizontalMonthPadding={15}
     daySize={40}
-    navPrev={<Button icon="keyboard_arrow_left" />}
-    navNext={<Button icon="keyboard_arrow_right" />}
+    navPrev={<Button subtle icon="keyboard_arrow_left" />}
+    navNext={<Button subtle icon="keyboard_arrow_right" />}
     {...otherProps}
   />
 )

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -49,7 +49,7 @@ const Filter = ({
     onClose && onClose()
 
     // Prevent form submission.
-    event.preventDefault()
+    event?.preventDefault()
   }
 
   const handleClear = () => {


### PR DESCRIPTION
Uma leve mudança nos botões do calendário. Na nova versão do Orion, o estado de resting do botão é sem o círculo cinza.

Antes:
![Capture d’écran 2021-02-12 à 11 37 22](https://user-images.githubusercontent.com/9112403/107781867-28c3ba00-6d27-11eb-843d-f53891fc9225.png)

Depois:
![Capture d’écran 2021-02-12 à 11 37 36](https://user-images.githubusercontent.com/9112403/107781876-2b261400-6d27-11eb-94d1-e7e3a164afbc.png)
