### PR TITLE
Feature/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, they will be 
+# requested for review when someone opens a pull request.
+*       @FranciscoGileno 
+*       @marcelscr 
+*       @tcezarrod


### PR DESCRIPTION
Adicionando os CODEOWNERS como solicitado nesta thread do Slack:
https://incognia.slack.com/archives/C6DK4M473/p1614374780036500

Os codeowners serão automáticamente adicionados como revisores nos PRs abertos no projeto. 