### PR TITLE
feat(Table): set table row styles for classname instead of tag

### DIFF
--- a/packages/orion/src/Table/index.js
+++ b/packages/orion/src/Table/index.js
@@ -1,16 +1,26 @@
 import { Table as SemanticTable } from '@inloco/semantic-ui-react'
 import React from 'react'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
 
 import TableCell from './TableCell'
 import TableHeaderCell from './TableHeaderCell'
 
 const Table = props => <SemanticTable {...props} />
 
+const TableRow = ({ className, ...otherProps }) => (
+  <SemanticTable.Row className={cx('table-row', className)} {...otherProps} />
+)
+
+TableRow.propTypes = {
+  className: PropTypes.string
+}
+
 Table.Body = SemanticTable.Body
 Table.Cell = TableCell
 Table.Header = SemanticTable.Header
 Table.HeaderCell = TableHeaderCell
-Table.Row = SemanticTable.Row
+Table.Row = TableRow
 Table.Footer = SemanticTable.Footer
 
 export default Table

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -25,41 +25,45 @@
   @apply pr-16;
 }
 
-.orion.table tr:first-child th:first-child {
+.orion.table .table-row:first-child th:first-child {
   border-top-left-radius: 4px;
 }
 
-.orion.table tr:first-child th:last-child {
+.orion.table .table-row:first-child th:last-child {
   border-top-right-radius: 4px;
 }
 
-.orion.table tr:last-child th:first-child {
+.orion.table .table-row:last-child th:first-child {
   border-bottom-left-radius: 4px;
 }
 
-.orion.table tr:last-child th:last-child {
+.orion.table .table-row:last-child th:last-child {
   border-bottom-right-radius: 4px;
 }
 
 /** Body **/
 
-.orion.table tbody > tr > td {
+.orion.table tbody > .table-row {
+  @apply table-row;
+}
+
+.orion.table tbody > .table-row > td {
   @apply font-normal leading-20 text-base text-gray-900 p-0;
 }
 
-.orion.table tbody > tr > td:first-child > .inner-cell {
+.orion.table tbody > .table-row > td:first-child > .inner-cell {
   @apply border-l-1 pl-24;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
 }
 
-.orion.table tbody > tr > td:last-child > .inner-cell {
+.orion.table tbody > .table-row > td:last-child > .inner-cell {
   @apply border-r-1 pr-16;
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
 }
 
-.orion.table tbody > tr > td > .inner-cell {
+.orion.table tbody > .table-row > td > .inner-cell {
   @apply bg-white;
   @apply border-t-1 border-b-1 border-gray-900-8;
   @apply px-12 mt-8;
@@ -76,21 +80,21 @@
 
 /** Footer **/
 
-.orion.table tfoot > tr > td {
+.orion.table tfoot > .table-row > td {
   @apply p-0;
 }
 
-.orion.table tfoot > tr > td > .inner-cell {
+.orion.table tfoot > .table-row > td > .inner-cell {
   @apply bg-gray-900-8 mt-8 p-8;
 }
 
-.orion.table tfoot > tr > td:first-child > .inner-cell {
+.orion.table tfoot > .table-row > td:first-child > .inner-cell {
   @apply pl-24;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
 }
 
-.orion.table tfoot > tr > td:last-child > .inner-cell {
+.orion.table tfoot > .table-row > td:last-child > .inner-cell {
   @apply pr-16;
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
@@ -135,6 +139,6 @@
 }
 
 /** Selectable **/
-.orion.table.selectable tbody > tr:hover > td > .inner-cell {
+.orion.table.selectable tbody > .table-row:hover > td > .inner-cell {
   @apply bg-gray-900-4;
 }


### PR DESCRIPTION
Os estilos das linhas da tabela estão definidos diretamente com a tag `tr`. Isso faz com que não possamos trocar o elemento usado para a linha (usar um `a`, por exemplo) ou o estilo se perderia. E.g.:
![Capture d’écran 2021-03-04 à 12 52 26](https://user-images.githubusercontent.com/9112403/109991350-04854880-7ce9-11eb-8192-420b3d43d0f0.png)

Então estou adicionando uma classe no Table.Row e trocando as regras de estilo para usarem esta classe. Assim, podemos trocar o elemento da linha. 
![Capture d’écran 2021-03-04 à 12 50 30](https://user-images.githubusercontent.com/9112403/109991592-34cce700-7ce9-11eb-8694-d147e4e5381e.png)
![Capture d’écran 2021-03-04 à 12 50 51](https://user-images.githubusercontent.com/9112403/109991578-31d1f680-7ce9-11eb-96f3-f7b79d20a4f1.png)
![Table link](https://user-images.githubusercontent.com/9112403/109991617-3b5b5e80-7ce9-11eb-975a-7565dcde612e.gif)



Isso vai ser útil na tabela dos dashes de POV para linkar para a página de detalhes, ao invés de usar o state + redirect.
