### PR TITLE
Feature/Table.cell 'as' prop

### DIFF
--- a/packages/orion/src/Table/TableCell/index.js
+++ b/packages/orion/src/Table/TableCell/index.js
@@ -19,6 +19,8 @@ const TableCell = ({
   content,
   highlight,
   horizontalAlign,
+  as,
+  href,
   ...otherProps
 }) => {
   const classes = cx('orion inner-cell', className, { highlight })
@@ -26,13 +28,18 @@ const TableCell = ({
     [ALIGN_TO_JUSTIFY_CONTENT[horizontalAlign]]: !!horizontalAlign
   })
   const childContent = content || children
+
+  // Infer anchor links;
+  // If the href prop were passed to SemanticTable.Cell,
+  // the td would be inferred to an anchor
+  const ElementType = href ? 'a' : as
   return (
     <SemanticTable.Cell
       title={_.isString(childContent) ? childContent : null}
       {...otherProps}>
-      <div className={classes}>
+      <ElementType className={classes}>
         <div className={wrapperClasses}>{childContent}</div>
-      </div>
+      </ElementType>
     </SemanticTable.Cell>
   )
 }
@@ -42,7 +49,13 @@ TableCell.propTypes = {
   className: PropTypes.string,
   content: PropTypes.node,
   highlight: PropTypes.bool,
-  horizontalAlign: PropTypes.oneOf(_.values(HorizontalAlignValues))
+  horizontalAlign: PropTypes.oneOf(_.values(HorizontalAlignValues)),
+  as: PropTypes.elementType,
+  href: PropTypes.string
+}
+
+TableCell.defaultProps = {
+  as: 'div'
 }
 
 // Overriding original factory. See src/utils/factories.js for more details.

--- a/packages/orion/src/Table/table.css
+++ b/packages/orion/src/Table/table.css
@@ -65,8 +65,8 @@
 }
 
 .orion.table tbody > .table-row > td > .inner-cell {
-  @apply bg-white;
-  @apply border-t-1 border-b-1 border-gray-900-8;
+  @apply bg-white text-gray-900 font-normal;
+  @apply block border-t-1 border-b-1 border-gray-900-8;
   @apply px-12 mt-8;
   height: 54px;
 }


### PR DESCRIPTION
Okay, outra tentativa de solução do problema dos links na tabela.
Já que não podemos transformar a `tr` em outro elemento, pensei em colocar o link em cada `Table.Cell`. Porém, se eu passar o `as` para o `Table.Cell` ele vai transforma o `td` no que eu disser. E isso tbm torna o html inválido, pq o `tr` tbm tem restrições nos elementos filhos permitidos:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr#technical_summary

Então estou capturando aqui a prop `as` (e a `href` tbm, pq se repassada, a inferencia seria feita no `SemanticTable.Cell`) e passando para o inner-cell.

Isso traz a transformação em URL que quero ao nível da célula. O lado negativo é q se eu precisar da linha toda como um Link, preciso passar a prop em cada `Table.Cell`. Mas acho q isso resolve nosso problema e conseguimos ficar com links na tabela. O que vocês acham?

![Capture d’écran 2021-03-05 à 13 25 58](https://user-images.githubusercontent.com/9112403/110143897-82635580-7db6-11eb-8634-23a367258714.png)
