### PR TITLE
Feature/Typography font-weight

### DIFF
--- a/packages/atomic-bomb/css/font.css
+++ b/packages/atomic-bomb/css/font.css
@@ -1,3 +1,5 @@
+/* Adapted from https://use.typekit.net/jsf0fxl.css */
+
 /* Neue Haas Grotesk Text */
 @font-face {
   font-family: 'neue-haas-grotesk-text';

--- a/packages/atomic-bomb/css/font.css
+++ b/packages/atomic-bomb/css/font.css
@@ -1,38 +1,66 @@
-@import url('https://p.typekit.net/p.css?s=1&k=zvb5ifp&ht=tk&f=39494.39504.39506&a=10618010&app=typekit&e=css');
-
-@font-face {
-  font-family: 'neue-haas-grotesk-display';
-  src: url('https://use.typekit.net/af/8a200c/00000000000000003b9b204a/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
-      format('woff2'),
-    url('https://use.typekit.net/af/8a200c/00000000000000003b9b204a/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
-      format('woff'),
-    url('https://use.typekit.net/af/8a200c/00000000000000003b9b204a/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
-      format('opentype');
-  font-display: auto;
-  font-style: normal;
-  font-weight: 600;
-}
-
+/* Neue Haas Grotesk Text */
 @font-face {
   font-family: 'neue-haas-grotesk-text';
-  src: url('https://use.typekit.net/af/1285d2/00000000000000003b9b2050/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
+  src: url('https://use.typekit.net/af/0230dd/00000000000000007735bb33/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
       format('woff2'),
-    url('https://use.typekit.net/af/1285d2/00000000000000003b9b2050/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
+    url('https://use.typekit.net/af/0230dd/00000000000000007735bb33/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
       format('woff'),
-    url('https://use.typekit.net/af/1285d2/00000000000000003b9b2050/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
+    url('https://use.typekit.net/af/0230dd/00000000000000007735bb33/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3')
       format('opentype');
+  font-display: auto;
   font-style: normal;
   font-weight: 400;
 }
 
 @font-face {
   font-family: 'neue-haas-grotesk-text';
-  src: url('https://use.typekit.net/af/550c82/00000000000000003b9b2052/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
+  src: url('https://use.typekit.net/af/160664/00000000000000007735bb32/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
       format('woff2'),
-    url('https://use.typekit.net/af/550c82/00000000000000003b9b2052/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
+    url('https://use.typekit.net/af/160664/00000000000000007735bb32/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
       format('woff'),
-    url('https://use.typekit.net/af/550c82/00000000000000003b9b2052/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
+    url('https://use.typekit.net/af/160664/00000000000000007735bb32/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
       format('opentype');
+  font-display: auto;
+  font-style: normal;
+  font-weight: 500;
+}
+
+/* Neue Haas Grotesk Display */
+@font-face {
+  font-family: 'neue-haas-grotesk-display';
+  src: url('https://use.typekit.net/af/99b799/00000000000000007735bb38/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n2&v=3')
+      format('woff2'),
+    url('https://use.typekit.net/af/99b799/00000000000000007735bb38/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n2&v=3')
+      format('woff'),
+    url('https://use.typekit.net/af/99b799/00000000000000007735bb38/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n2&v=3')
+      format('opentype');
+  font-display: auto;
+  font-style: normal;
+  font-weight: 200;
+}
+
+@font-face {
+  font-family: 'neue-haas-grotesk-display';
+  src: url('https://use.typekit.net/af/1ba16c/00000000000000007735bb5a/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
+      format('woff2'),
+    url('https://use.typekit.net/af/1ba16c/00000000000000007735bb5a/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
+      format('woff'),
+    url('https://use.typekit.net/af/1ba16c/00000000000000007735bb5a/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3')
+      format('opentype');
+  font-display: auto;
+  font-style: normal;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: 'neue-haas-grotesk-display';
+  src: url('https://use.typekit.net/af/153042/00000000000000007735bb62/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
+      format('woff2'),
+    url('https://use.typekit.net/af/153042/00000000000000007735bb62/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
+      format('woff'),
+    url('https://use.typekit.net/af/153042/00000000000000007735bb62/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3')
+      format('opentype');
+  font-display: auto;
   font-style: normal;
   font-weight: 500;
 }

--- a/packages/atomic-bomb/tailwind.config.js
+++ b/packages/atomic-bomb/tailwind.config.js
@@ -256,6 +256,7 @@ module.exports = {
       'icon-md': '20px'
     },
     fontWeight: {
+      thin: '200',
       normal: '400',
       medium: '500'
     },

--- a/packages/orion/src/Typography.stories.js
+++ b/packages/orion/src/Typography.stories.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { text, number } from '@storybook/addon-knobs'
+
+const storyMetadata = {
+  title: 'Typography'
+}
+
+export default storyMetadata
+
+export const basic = () => {
+  const customText = text('Text', 'The quick brown fox jumps over 42 lazy dogs')
+  const fontSize = number('Font size', 16, { range: true, min: 12, max: 56 })
+  return (
+    <div style={{ fontSize, lineHeight: `${fontSize + 6}px` }}>
+      <div className="font-normal">{customText}</div>
+      <div className="font-medium">{customText}</div>
+
+      <div className="font-display font-thin">{customText}</div>
+      <div className="font-display font-normal">{customText}</div>
+      <div className="font-display font-medium">{customText}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
Precisamos da variante `thin` (font-weight 200) da fonte `Neue Haas Grotesk Display`, mas ainda não tínhamos aqui.

Pedi para Cris pegar para mim lá no [site da Adobe](https://fonts.adobe.com/fonts/neue-haas-grotesk#fonts-section)

Eu poderia apenas importar da url https://use.typekit.net/jsf0fxl.css, que já define todos esses font-faces, mas ao fazer isso notei que a variante `Display` tem um fontweight diferente da variante `Text` para os pesos `normal` e `medium`. Para o `Display` os normal e medium são 500 e 600, respectivamente, mas nas nossas regras, eles são 400 e 500.
Então mantive a declaração dos `font-face` direto aqui no `font.css` para que pudesse ajustar de acordo.

O medium era o único que tínhamos disponível para a Display, e agora podemos usar tbm `normal` e `thin`. Mas a variante Text não tem o peso `thin`, por isso temos 5 e não 6:
![orion typography](https://user-images.githubusercontent.com/9112403/112893362-f1c81e80-90b0-11eb-9727-ae94d9811ea6.gif)

A fim de comparação, o que tínhamos antes para as mesmas regras ficava assim (Percebam que os três últimos estão iguais, pois só tínhamos o `medium` para a variante `Display`:
![Capture d’écran 2021-03-29 à 14 55 21](https://user-images.githubusercontent.com/9112403/112893433-0efced00-90b1-11eb-9f62-fad2ac79b26b.png)

