### PR TITLE
Fix/Head font medium

### DIFF
--- a/packages/atomic-bomb/css/base.css
+++ b/packages/atomic-bomb/css/base.css
@@ -11,7 +11,7 @@ body {
 
 h1,
 h2 {
-  @apply font-display text-lg text-gray-800 leading-24;
+  @apply font-display font-medium text-lg text-gray-800 leading-24;
 }
 
 a {

--- a/packages/orion/src/Filter/filter.css
+++ b/packages/orion/src/Filter/filter.css
@@ -51,7 +51,7 @@
 }
 
 .orion.popup.filter .filter-footer-content {
-  @apply leading-14 font-display mr-8 text-sm text-gray-800;
+  @apply leading-14 font-display font-medium mr-8 text-sm text-gray-800;
 }
 
 /** Prefix **/

--- a/packages/orion/src/FullscreenContainer/fullscreenContainer.css
+++ b/packages/orion/src/FullscreenContainer/fullscreenContainer.css
@@ -3,7 +3,7 @@
 }
 
 .orion.fullscreen-container .fullscreen-container-title {
-  @apply font-display text-lg mb-24 text-gray-800;
+  @apply font-display font-medium text-lg mb-24 text-gray-800;
 }
 
 .orion.fullscreen-container .fullscreen-container-content {

--- a/packages/orion/src/Modal/modal.css
+++ b/packages/orion/src/Modal/modal.css
@@ -48,7 +48,7 @@
 ---------------*/
 
 .orion.modal > .header {
-  @apply block bg-transparent px-24 pt-24 font-display text-lg text-gray-800;
+  @apply block bg-transparent px-24 pt-24 font-display font-medium text-lg text-gray-800;
 }
 
 /*--------------


### PR DESCRIPTION
Esqueci que os `h1` e `h2` tbm estavam com o estilo do `font-display` que foi alterado no último release. Eles precisam estar com o peso `medium` tbm, então estou corrigindo aqui.