### PR TITLE
Fix/Layout alert info color

### DIFF
--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -138,7 +138,7 @@
 }
 
 .orion.layout .layout-alert.info {
-  @apply bg-gray-900-8;
+  @apply bg-gray-200;
 }
 
 .orion.layout .layout-alert.warning > .icon {


### PR DESCRIPTION
Havia setado a cor do alerta cinza para gray-900 com opacidade .08, mas a opacidade atrapalha a visibilidade pq o alerta pode ficar por cima de outros elementos:
![Transparent topbar](https://user-images.githubusercontent.com/9112403/113146148-b3904380-9205-11eb-90b9-6266e3f6a8bc.gif)

Cris falou que essa cor é equivalente ao `gray-200` então estou atualizando para o alerta ficar com esta cor sólida
![fix gray alert](https://user-images.githubusercontent.com/9112403/113146193-c1de5f80-9205-11eb-9983-9b5ee038e3cf.gif)
