### PR TITLE
Feature/card selectable

### DIFF
--- a/packages/orion/src/Card/card.css
+++ b/packages/orion/src/Card/card.css
@@ -55,8 +55,8 @@
   @apply absolute top-0 left-0;
 }
 
-.orion.card.selectable.selected:not(.disabled):not(.read-only) > .card-icon {
-  @apply text-robinblue-500;
+.orion.card.selectable:not(.disabled):not(.read-only) > .card-icon {
+  @apply text-purple-800;
 }
 
 /***
@@ -75,18 +75,22 @@
 }
 
 .orion.card.selectable.selected {
-  @apply bg-robinblue-500-8 shadow-none;
+  @apply bg-purple-100 shadow-none;
 }
 .orion.card.selectable.selected:hover,
 .orion.card.selectable.selected:focus {
   @apply border-gray-900-16 shadow-200;
 }
 .orion.card.selectable.selected:active {
-  @apply bg-robinblue-500-16 shadow-none;
+  @apply bg-purple-200 shadow-none;
 }
 
 .orion.card.selectable .checkbox {
   @apply absolute left-0 top-0 m-8;
+}
+
+.orion.card.selectable > .content {
+  @apply text-purple-800;
 }
 
 /***


### PR DESCRIPTION
Cristiano pediu para que o Card fique com a cor de purple quando estiver selecionado.

A questão é que antes ele ficava com cor da fonte cinza, e só se estivesse selecionado ele ficava `robinblue`.

Sendo que agora ele quer que já comece purple.

Antes:
![2021-03-31 18 23 30](https://user-images.githubusercontent.com/1139664/113213349-70a68e00-924e-11eb-86f3-8149a1a7d7b1.gif)

Depois:
![2021-03-31 18 23 06](https://user-images.githubusercontent.com/1139664/113213366-7a2ff600-924e-11eb-9551-dbd0e60451a2.gif)
