### PR TITLE
feature(status-tag): Change colors

### DIFF
--- a/packages/orion/src/StatusTag/statusTag.css
+++ b/packages/orion/src/StatusTag/statusTag.css
@@ -40,7 +40,7 @@
 }
 
 .orion.status-tag.inactive.bordered {
-  @apply border-gray-700;
+  @apply border-gray-400;
 }
 
 .orion.status-tag.inactive .icon {
@@ -52,19 +52,19 @@
 ---------------*/
 
 .orion.status-tag.neutral {
-  @apply text-purple-700;
+  @apply text-gray-900;
 }
 
 .orion.status-tag.neutral.filled {
-  @apply bg-purple-100;
+  @apply bg-gray-200;
 }
 
 .orion.status-tag.neutral.bordered {
-  @apply border-purple-600;
+  @apply border-gray-700;
 }
 
 .orion.status-tag.neutral .icon {
-  @apply text-purple-500;
+  @apply text-gray-700;
 }
 
 /*--------------


### PR DESCRIPTION
Conversei com Cristiano, e notamos que os status do `<StatusTag />` estavam errados para o `neutral`.

Antes o `neutral` estava definido pra ser um `space`, e com o rebranding, ele se tornou um `purple`, o que o deixou assim:
![image](https://user-images.githubusercontent.com/1139664/113333889-64c3d600-92f9-11eb-8f65-9f38203a539c.png)

Sendo que isto não é nada neutro. Então Cristiano decidiu que o Neutro deveria ficar assim:
![image](https://user-images.githubusercontent.com/1139664/113334009-87ee8580-92f9-11eb-9c42-a14321709107.png)

Ainda existe o status `inactive`,  que é o neutro, mais claro:
![image](https://user-images.githubusercontent.com/1139664/113334171-c2f0b900-92f9-11eb-8c7d-dc247828b7db.png)

Como podem ver, os ajustes no Orion foram mínimos, porém no `inloco-frontend` há várias referências ao `inactive`, quando na verdade ele deveria estar apontando para o `neutral`. Então vai rolar um refactoring por lá também.