### PR TITLE
Fix/Apps dropdown no wrap

### DIFF
--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -39,14 +39,14 @@ export const basic = () => (
           'Options',
           [
             {
-              text: 'Incognia',
-              value: 'incognia',
+              text: 'Risk assessments',
+              value: 'riskAssessments',
               image: { as: () => <img alt="app" src={incognia} /> },
               selected: true
             },
             {
-              text: 'My apps',
-              value: 'myapps',
+              text: 'Integrations',
+              value: 'integrations',
               image: { as: () => <img alt="app" src={myapps} /> }
             }
           ],

--- a/packages/orion/src/Layout/LayoutAppsDropdown/index.js
+++ b/packages/orion/src/Layout/LayoutAppsDropdown/index.js
@@ -37,7 +37,7 @@ const LayoutAppsDropdown = ({
                 <Image {...image} />
               </div>
             )}
-            <div>{text}</div>
+            <div className="layout-apps-dropdown-text">{text}</div>
           </Dropdown.Header>
         ))}
         <Dropdown.Divider />
@@ -49,7 +49,7 @@ const LayoutAppsDropdown = ({
                   <Image {...image} />
                 </div>
               )}
-              <div>{text}</div>
+              <div className="layout-apps-dropdown-text">{text}</div>
             </Dropdown.Item>
           )
         })}

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -80,7 +80,7 @@
  * Apps Dropdown Menu
  */
 .orion.layout .layout-apps-dropdown > .menu {
-  @apply bg-gray-100 left-0;
+  @apply bg-gray-100 left-0 w-auto;
   min-width: 206px;
   transform: translateX(calc(-50% + 20px));
 }
@@ -118,6 +118,13 @@
 
 .orion.layout .layout-apps-dropdown-image > .orion.image {
   @apply mx-0;
+}
+
+/**
+ * Apps Dropdown Text
+ */
+.orion.layout .layout-apps-dropdown-text {
+  @apply whitespace-no-wrap;
 }
 
 /**


### PR DESCRIPTION
I'm addin `whitespace: no-wrap` to the dropdown texts because longer labels were breaking lines, giving a bad visual aspect to the component

Before:
![Capture d’écran 2021-04-29 à 13 08 37](https://user-images.githubusercontent.com/9112403/116583656-f6206b00-a8ec-11eb-81d3-888c409c09d5.png)


Now:
![Capture d’écran 2021-04-29 à 13 10 31](https://user-images.githubusercontent.com/9112403/116583665-f91b5b80-a8ec-11eb-9202-1abf94e68692.png)

