### PR TITLE
Fix/Tour body scroll

### DIFF
--- a/packages/orion/src/Tour/index.js
+++ b/packages/orion/src/Tour/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import Reactour from 'reactour'
@@ -36,11 +36,6 @@ function Tour({
   const [openModal, setOpenModal] = useState(!!welcomeModal)
   const tourSteps = useMemo(() => parseSteps(steps), [steps])
   const badgePosition = useBadgePosition(tourSteps, currentStep)
-
-  useEffect(() => {
-    disableBodyScroll()
-    return () => enableBodyScroll()
-  }, [])
 
   function handleStepActions(stepIndex, nextStepIndex) {
     const actionBefore = tourSteps[nextStepIndex]?.actionBefore
@@ -95,7 +90,8 @@ function Tour({
         steps={tourSteps}
         closeWithMask={false}
         CustomHelper={TourHelper}
-        onBeforeClose={() => enableBodyScroll()}
+        onAfterOpen={target => disableBodyScroll(target)}
+        onBeforeClose={target => enableBodyScroll(target)}
         onRequestClose={() => {
           setOpenTour(false)
           handleStepActions(currentStep)


### PR DESCRIPTION
Ao abrir um Tour, o body scroll deve ser desabilitado (o tour tem um bug se o body scroll estiver habilitado: a "janela" selecionada não move com o scroll).

Porém eu havia configurado de forma errada, e o lock não estava funcionando 🤡 

Estou corrigindo para usar a forma recomendada na doc do reactour:
https://github.com/elrumordelaluz/reactour#faq