### PR TITLE
Fix/Tour body scroll effect

### DIFF
--- a/packages/orion/src/Tour/index.js
+++ b/packages/orion/src/Tour/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import Reactour from 'reactour'
@@ -36,6 +36,15 @@ function Tour({
   const [openModal, setOpenModal] = useState(!!welcomeModal)
   const tourSteps = useMemo(() => parseSteps(steps), [steps])
   const badgePosition = useBadgePosition(tourSteps, currentStep)
+  const scrollTarget = React.useRef()
+
+  useEffect(() => {
+    if (!openTour) return
+
+    return () => {
+      enableBodyScroll(scrollTarget.current)
+    }
+  }, [openTour])
 
   function handleStepActions(stepIndex, nextStepIndex) {
     const actionBefore = tourSteps[nextStepIndex]?.actionBefore
@@ -90,8 +99,10 @@ function Tour({
         steps={tourSteps}
         closeWithMask={false}
         CustomHelper={TourHelper}
-        onAfterOpen={target => disableBodyScroll(target)}
-        onBeforeClose={target => enableBodyScroll(target)}
+        onAfterOpen={target => {
+          disableBodyScroll(target)
+          scrollTarget.current = target
+        }}
         onRequestClose={() => {
           setOpenTour(false)
           handleStepActions(currentStep)


### PR DESCRIPTION
Revertendo o "fix" do PR https://github.com/inloco/orion/pull/1067 e fazendo da forma correta agora.

### Problema
Após o fix acima, o scroll passou a ser desabilitado ao iniciar o tour, como queríamos. Porém, ao encerrar, ele não era habilitado de volta.

### Identificação do problema

A razão para o `enableBodyScroll` estar num cleanup do useEffect era a seguinte:
Da forma que o `reactour` recomenda, chamando no `onBeforeClose` exige que o componente esteja renderizado para que o callback possa ser chamado. E estava funcionando maravilhoso aqui no storybook do orion pq o Tour só some de acordo com o estado interno. 

Porém, lá no produto, quando o tour é encerrado, a gente não renderiza mais o componente (retornando `null`), e por isso o método para reabilitar o scroll acabava não sendo executado corretamente. 
Podemos simular este caso aqui fazendo algo assim:
![Capture d’écran 2021-04-29 à 17 01 22](https://user-images.githubusercontent.com/9112403/116699843-7520ac80-a99c-11eb-94c1-f0f3e088975d.png)
(se open for `false` o componente não vai ser renderizado)

E com isso, consegui reproduzir o problema aqui. Ao fechar o tour, o scroll não voltava:
![scroll bug](https://user-images.githubusercontent.com/9112403/116699941-91bce480-a99c-11eb-976a-1820a8b7feb6.gif)

Isso acontece pois, ao ocultar o componente, o pedaço `onBeforeClose={target => enableBodyScroll(target)}` não funciona com esperado.

### Solução
Mantive o `enableBodyScroll` em um `useEffect` que depende do booleano `openTour`. Quando o booleano for `true`, o efeito retornará um cleanup que chamará o `enableBodyScroll`. O problema com como estava antes é que as funções de `enableBodyScroll` e `disableBodyScroll` precisam de um argumento indicando o componente onde o controle de scroll vai ser transferido (ao ser removido do body). Sem elas, as funções não estavam funcionando, por isso o scroll não estava sendo desabilitado. Então para o `disableBodyScroll`, estou mantendo o target retornado pelo `onAfterOpen`. E daí gravo esse target numa ref para ser usada no cleanup ao chamar o `enableBodyScroll`.
Com essa abordagem ao invés de chamar o `onBeforeClose`, o scroll vai voltar nos dois casos:
- Se o tour for fechado apenas pelo estado interno, pois a transação do `openTour` de `true` -> `false` vai triggar o cleanup
- Se o tour deixar de ser renderizado, pois nesse momento o cleanup também é executado

Assim o problema foi resolvido:
![scroll nice](https://user-images.githubusercontent.com/9112403/116700548-4820c980-a99d-11eb-8f9f-559aa04061b6.gif)
