### PR TITLE
feature(Pagination): add the value prop on i18n

### DIFF
--- a/packages/orion/src/Pagination/Pagination.stories.js
+++ b/packages/orion/src/Pagination/Pagination.stories.js
@@ -68,3 +68,22 @@ export const alignButtonsLeft = () => (
     {...actions}
   />
 )
+
+export const customValue = () => (
+  <Pagination
+    activePage={number('activePage', 1)}
+    disabled={boolean('disabled', false)}
+    totalItems={number('totalItems', 23)}
+    pageSize={number('pageSize', 10)}
+    alignButtonsLeft={boolean('alignButtonsLeft', false)}
+    i18n={object('i18n', {
+      language: 'en',
+      of: 'of',
+      value: 'many',
+      results: 'results'
+    })}
+    loading={boolean('loading', false)}
+    size={sizeKnob(Sizes.DEFAULT)}
+    {...actions}
+  />
+)

--- a/packages/orion/src/Pagination/Pagination.test.js
+++ b/packages/orion/src/Pagination/Pagination.test.js
@@ -70,6 +70,24 @@ describe('Happy path', () => {
     expect(queryByText(expectedResult)).toBeTruthy()
   })
 
+  describe('when the i18n prop is passed', () => {
+    it('should show the correct strings', () => {
+      const { getByText, queryByText } = render(
+        <Pagination
+          activePage={1}
+          pageSize={10}
+          totalItems={35}
+          i18n={{ of: 'of', value: 'many', results: 'results' }}
+        />
+      )
+      expect(getByText('1-10')).toBeInTheDocument()
+      expect(getByText('of')).toBeInTheDocument()
+      expect(getByText('many')).toBeInTheDocument()
+      expect(getByText('results')).toBeInTheDocument()
+      expect(queryByText('35')).not.toBeInTheDocument()
+    })
+  })
+
   describe('buttons', () => {
     it('should show previous button disabled if it is on first page', () => {
       const { queryByTestId } = render(

--- a/packages/orion/src/Pagination/index.js
+++ b/packages/orion/src/Pagination/index.js
@@ -64,7 +64,7 @@ const Pagination = ({
             </span>
             <span className="orion-pagination-text">{i18n.of}</span>
             <span className="orion-pagination-value">
-              {totalItems.toLocaleString(i18n.language)}
+              {i18n.value ?? totalItems.toLocaleString(i18n.language)}
             </span>
           </>
         )}
@@ -111,6 +111,7 @@ Pagination.propTypes = {
   i18n: PropTypes.shape({
     language: PropTypes.string,
     of: PropTypes.string,
+    value: PropTypes.string,
     results: PropTypes.string
   }),
   onPageChange: PropTypes.func,


### PR DESCRIPTION
Esse PR adiciona uma nova prop `value` no objeto `i18n` pra permitir passar valores arbitrários pro `Pagination`. Caso o `value` seja setado, ele substitui o valor default que é o `totalItems`.

<img width="288" alt="Screen Shot 2021-06-15 at 16 26 17" src="https://user-images.githubusercontent.com/28961613/122235418-0fc54400-ce94-11eb-9685-e215f3851011.png">

Achei melhor não colocar agora a lógica de `hasNext`, pois o componente é bem dependente do `totalItems` e esse uso de `hasNext` vai ser um edge case. Minha sugestão é que a gente faça o `hasNext` funcionar lá no `inloco-frontend` se aproveitando de que o `totalItems` não é renderizado nesse caso.

Um exemplo de solução simples que simularia um `hasNext` é o seguinte:
1.   Se `hasNext === true`, totalItems = MAX_VALUE 
* O botão de next sempre estará habilitado
2.  Se `hasNext === false`, totalItems = (currentPage - 1) * pageSize + installations.length  
* Calcula o total de itens confirmados e desabilita o botão de next

Acham que assim funciona ou é gambi? @ottony @julianalucena 