### PR TITLE
feature(user-profile-footer): Add user pofile footer

### DIFF
--- a/packages/orion/src/Layout/Layout.stories.js
+++ b/packages/orion/src/Layout/Layout.stories.js
@@ -19,6 +19,22 @@ const paragraphs = _.times(10, () =>
   loremIpsum({ count: 1, units: 'paragraph' })
 )
 
+const Footer = (
+  <div className="flex justify-center items-center p-8 border-t-1 border-gray-900-16 space-x-8">
+    <a href="/help" className="text-sm font-normal text-gray-800">
+      Help
+    </a>
+    <div className="bg-gray-800 w-4 h-4 rounded-full" />
+    <a href="/privacy-policy" className="text-sm font-normal text-gray-800">
+      Privacy Policy
+    </a>
+    <div className="bg-gray-800 w-4 h-4 rounded-full" />
+    <a href="/terms-of-use" className="text-sm font-normal text-gray-800">
+      Terms of Use
+    </a>
+  </div>
+)
+
 export const basic = () => (
   <Layout className="flex w-full">
     <Layout.Sidebar>
@@ -75,6 +91,7 @@ export const basic = () => (
           name={text('Name', 'Mark Weiser', 'UserProfile')}
           label={text('Label', 'Incognia', 'UserProfile')}
           email={text('Email', 'mark.weiser@incognia.com', 'UserProfile')}
+          footer={Footer}
           logoutUrl={text('Logout URL', '#', 'UserProfile')}
           logoutText={text('Logout Text', 'Logout', 'UserProfile')}
           imageUrl={text('Image URL', appImage, 'UserProfile')}>

--- a/packages/orion/src/Layout/LayoutUserProfile/index.js
+++ b/packages/orion/src/Layout/LayoutUserProfile/index.js
@@ -16,6 +16,7 @@ const LayoutUserProfile = ({
   children,
   name,
   email,
+  footer,
   label,
   logoutUrl,
   logoutText,
@@ -94,6 +95,7 @@ const LayoutUserProfile = ({
             {logoutText}
           </button>
         </form>
+        {footer}
       </Dropdown.Menu>
     </Dropdown>
   )
@@ -104,6 +106,7 @@ LayoutUserProfile.propTypes = {
   children: PropTypes.node,
   name: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
+  footer: PropTypes.node,
   label: PropTypes.string,
   logoutUrl: PropTypes.string,
   logoutText: PropTypes.string,

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -14,7 +14,7 @@
  * Topbar
  */
 .orion.layout .layout-topbar {
-  @apply fixed top-0 z-40 px-24;
+  @apply fixed top-0 z-40 px-24 bg-gray-50;
   @apply items-center h-64 flex justify-center;
   width: calc(100% - 238px);
 }


### PR DESCRIPTION
Adicionei uma prop `footer` no `<Layout.UserProfile />`.

Diante de como está implementado, achei a opção mais genérica.

O footer vai servir pra adicionar os links no footer do UserProfile:
![image](https://user-images.githubusercontent.com/1139664/123638347-741dc700-d7f5-11eb-9355-9ce4a99ccb3c.png)

O que achas @marcelscr ?