### PR TITLE
feature(Filter): add the clearable prop

### DIFF
--- a/packages/orion/src/Filter/Filter.stories.js
+++ b/packages/orion/src/Filter/Filter.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import { object, text } from '@storybook/addon-knobs'
+import { object, text, boolean } from '@storybook/addon-knobs'
 import PropTypes from 'prop-types'
 import _ from 'lodash'
 
@@ -25,6 +25,7 @@ export const withInput = () => (
     text={text('Label', 'Open')}
     extraFooterContent={text('Extra footer content', '')}
     prefix={text('Prefix', '')}
+    clearable={boolean('Clearable', true)}
     {...actions}>
     {filterProps => (
       <FilterStoryInput {...filterProps} placeholder="Type your name" />
@@ -42,6 +43,7 @@ export const withDropdown = () => {
       prefix={text('Prefix', '')}
       text={text('Label', 'Open')}
       selectedText={value => value.map(index => options[index].text).join(', ')}
+      clearable={boolean('Clearable', true)}
       {...actions}>
       {({ onChange, value }) => (
         <React.Fragment>
@@ -85,6 +87,7 @@ export const withHover = () => (
       position: text('Tooltip position', 'right center'),
       content: text('Hover Content', 'This is a filter')
     }}
+    clearable={boolean('Clearable', true)}
     {...actions}>
     {filterProps => (
       <FilterStoryInput {...filterProps} placeholder="Type your name" />
@@ -111,6 +114,7 @@ export const customApply = () => {
       text={text('Label', 'Filter')}
       applyButton={null}
       clearButton={null}
+      clearable={boolean('Clearable', true)}
       {...actions}>
       {({ handleApply }) => (
         <Button

--- a/packages/orion/src/Filter/Filter.test.js
+++ b/packages/orion/src/Filter/Filter.test.js
@@ -1,6 +1,6 @@
 import keyboardKey from 'keyboard-key'
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import Filter from './'
 
@@ -239,6 +239,32 @@ describe("when the filter's value changes", () => {
 
     it('should call "onChange" with "null"', () => {
       expect(onChange).toHaveBeenCalledWith(null)
+    })
+  })
+})
+
+describe('when the filter is not clearable', () => {
+  const value = 'Controlled value'
+
+  beforeEach(() => {
+    render(
+      <Filter text="Open" value={value} clearable={false}>
+        {childFn}
+      </Filter>
+    )
+  })
+
+  it('should not render a cancel icon', () => {
+    expect(screen.queryByText('clear')).not.toBeInTheDocument()
+  })
+
+  describe('when the popup is open', () => {
+    it('should not render the clear button', () => {
+      fireEvent.click(screen.getByText(value))
+
+      expect(
+        screen.queryByRole('button', { name: 'Clear' }).closest('div')
+      ).toHaveClass('invisible')
     })
   })
 })

--- a/packages/orion/src/Filter/filter.css
+++ b/packages/orion/src/Filter/filter.css
@@ -19,6 +19,9 @@
 
 .orion.button.filter-trigger.selected {
   @apply bg-purple-100 border-none text-purple-800;
+}
+
+.orion.button.filter-trigger.selected.clearable {
   @apply pr-8;
 }
 

--- a/packages/orion/src/Filter/index.js
+++ b/packages/orion/src/Filter/index.js
@@ -29,6 +29,7 @@ const Filter = ({
   trigger,
   value: propValue,
   tooltipProps,
+  clearable,
   ...otherProps
 }) => {
   const [open, setOpen] = useState(false)
@@ -86,7 +87,8 @@ const Filter = ({
 
   const triggerClasses = cx('filter-trigger', {
     active: open,
-    selected: isSelected
+    selected: isSelected,
+    clearable
   })
 
   const defaultTooltipTrigger = (
@@ -95,7 +97,9 @@ const Filter = ({
         <span className="filter-trigger-prefix">{prefix}</span>
       )}
       {isSelected ? selectedText(value) : text}
-      {isSelected && <FilterClearIcon onClick={handleClearIconClick} />}
+      {isSelected && clearable && (
+        <FilterClearIcon onClick={handleClearIconClick} />
+      )}
     </Button>
   )
 
@@ -129,7 +133,10 @@ const Filter = ({
         </div>
         {(clearButton || applyButton || extraFooterContent) && (
           <div className="filter-buttons">
-            <div className={cx({ invisible: _.isEmpty(localValue) })}>
+            <div
+              className={cx({
+                invisible: !clearable || _.isEmpty(localValue)
+              })}>
               {Button.create(clearButton, {
                 autoGenerateKey: false,
                 defaultProps: {
@@ -178,13 +185,15 @@ Filter.propTypes = {
   text: PropTypes.string,
   value: PropTypes.any,
   tooltipProps: PropTypes.object,
-  trigger: PropTypes.node
+  trigger: PropTypes.node,
+  clearable: PropTypes.bool
 }
 
 Filter.defaultProps = {
   applyButton: 'Apply',
   clearButton: 'Clear',
-  selectedText: value => value
+  selectedText: value => value,
+  clearable: true
 }
 
 export default Filter


### PR DESCRIPTION
Na lista de installations, o filtro de AppId vai ser obrigatório, não sendo possível limpá-lo através dos botões de clear - sempre terá um valor.

Com isso, adicionei essa prop pra ser possível esconder os botões de clear no componente de Filter.

![2021-06-29 10 42 30](https://user-images.githubusercontent.com/28961613/123811812-f8417e80-d8c9-11eb-95c1-321f35f568a6.gif)
