### PR TITLE
fix(layout): Fix layout spacement issues

### DIFF
--- a/packages/orion/src/Layout/LayoutSidebar/index.js
+++ b/packages/orion/src/Layout/LayoutSidebar/index.js
@@ -9,7 +9,7 @@ import Logo from '../../Logo'
 
 const LayoutSidebar = ({ className, children, logo, ...otherProps }) => (
   <div className={cx('layout-sidebar', className)} {...otherProps}>
-    {logo || <Logo className="sidebar-logo" />}
+    <div className="sidebar-logo">{logo || <Logo />}</div>
     {children}
   </div>
 )

--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -83,8 +83,8 @@
  */
 
 .orion.layout .layout-main {
-  @apply flex flex-col w-full justify-start bg-gray-50;
-  margin-left: 230px;
+  @apply flex flex-col justify-start bg-gray-50;
+  margin-left: 238px;
 }
 
 /**


### PR DESCRIPTION
Encontrei alguns problemas quando coloquei o Layout no produto:

1. A margin do main estava em 230px, enquanto o Sidebar tinha 238px. Notei que no Storybook funciona porque existe um elemento "root" do storybook que tinha margin de 8px e inteferia nisto. Mas no produto ficava desalinhado.
2. O Main estava com 100% de width com + 238px de margin, o que dava ruim. Tirando o 100% resolve.
3. Quando o logo é passado via props, os estilos não estava sendo setados pra ele.

Antes:
![image](https://user-images.githubusercontent.com/1139664/124030345-78e8a380-d9cc-11eb-8d2c-eeb16ff12e63.png)


Depois:
![image](https://user-images.githubusercontent.com/1139664/124030224-5e162f00-d9cc-11eb-8289-62a6f1e9924d.png)

