### PR TITLE
fix(sidebar-menu): Fix menu items hover style

### DIFF
--- a/packages/orion/src/Layout/layout.css
+++ b/packages/orion/src/Layout/layout.css
@@ -69,7 +69,12 @@
 
 .orion.layout .layout-sidebar .orion.menu .item:hover,
 .orion.layout .layout-sidebar .orion.menu .item:focus {
-  @apply bg-purple-50;
+  @apply bg-gray-200 text-purple-800 font-medium;
+}
+
+.orion.layout .layout-sidebar .orion.menu .item:hover > .icon,
+.orion.layout .layout-sidebar .orion.menu .item:focus > .icon {
+  @apply text-purple-700;
 }
 
 .orion.layout .layout-sidebar .orion.menu .item.active {


### PR DESCRIPTION
Corrigindo o estilo do item menu on hover:
![image](https://user-images.githubusercontent.com/1139664/125116931-d6af7680-e0c3-11eb-848a-9f85a171bb52.png)
